### PR TITLE
Removed aggregate id from events, blame Ross when hell freezes over.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,5 @@
 parameters:
+	ignoreErrors:
+		- '#Call to an undefined method EventSauce\\EventSourcing\\AggregateRootTestCase\:\:handle\(\)#'
 	excludes_analyse:
 		- %rootDir%/../../../src/CodeGeneration/Fixtures/*

--- a/src/AggregateRootRepository.php
+++ b/src/AggregateRootRepository.php
@@ -21,10 +21,20 @@ final class AggregateRootRepository
      */
     private $decorator;
 
-    public function __construct(string $aggregateRootClassName, MessageRepository $messageRepository, MessageDecorator $decorator = null)
-    {
+    /**
+     * @var MessageDispatcher
+     */
+    private $dispatcher;
+
+    public function __construct(
+        string $aggregateRootClassName,
+        MessageRepository $messageRepository,
+        MessageDispatcher $dispatcher = null,
+        MessageDecorator $decorator = null
+    ) {
         $this->aggregateRootClassName = $aggregateRootClassName;
         $this->repository = $messageRepository;
+        $this->dispatcher = $dispatcher ?: new SynchronousMessageDispatcher();
         $this->decorator = $decorator ?: new DelegatingMessageDecorator();
     }
 
@@ -57,5 +67,6 @@ final class AggregateRootRepository
         }, $events);
 
         $this->repository->persist($aggregateRootId, ... $messages);
+        $this->dispatcher->dispatch(... $messages);
     }
 }

--- a/src/AggregateRootRepository.php
+++ b/src/AggregateRootRepository.php
@@ -47,15 +47,15 @@ final class AggregateRootRepository
 
     public function persist(AggregateRoot $aggregateRoot)
     {
-        $this->persistEvents(...$aggregateRoot->releaseEvents());
+        $this->persistEvents($aggregateRoot->aggregateRootId(), ...$aggregateRoot->releaseEvents());
     }
 
-    public function persistEvents(Event ... $events)
+    public function persistEvents(AggregateRootId $aggregateRootId, Event ... $events)
     {
-        $messages = array_map(function(Event $event) {
-            return $this->decorator->decorate(new Message($event));
+        $messages = array_map(function(Event $event) use ($aggregateRootId) {
+            return $this->decorator->decorate(new Message($aggregateRootId, $event));
         }, $events);
 
-        $this->repository->persist(... $messages);
+        $this->repository->persist($aggregateRootId, ... $messages);
     }
 }

--- a/src/AggregateRootTestCase.php
+++ b/src/AggregateRootTestCase.php
@@ -3,10 +3,14 @@
 namespace EventSauce\EventSourcing;
 
 use Exception;
+use function func_get_args;
 use function get_class;
+use LogicException;
+use function method_exists;
 use PHPUnit\Framework\TestCase;
 use EventSauce\EventSourcing\Time\Clock;
 use EventSauce\EventSourcing\Time\TestClock;
+use function sprintf;
 
 abstract class AggregateRootTestCase extends TestCase
 {
@@ -18,12 +22,7 @@ abstract class AggregateRootTestCase extends TestCase
     /**
      * @var AggregateRootRepository
      */
-    private $repository;
-
-    /**
-     * @var CommandHandler
-     */
-    private $commandHandler;
+    protected $repository;
 
     /**
      * @var Exception|null
@@ -65,7 +64,6 @@ abstract class AggregateRootTestCase extends TestCase
         $this->aggregateRootId = $this->aggregateRootId();
         $this->messageRepository = new InMemoryMessageRepository($this->messageDispatcher());
         $this->repository = new AggregateRootRepository($className, $this->messageRepository, new DelegatingMessageDecorator());
-        $this->commandHandler = $this->commandHandler($this->repository, $this->clock);
         $this->expectedEvents = [];
         $this->assertedScenario = false;
         $this->theExpectedException = null;
@@ -98,8 +96,6 @@ abstract class AggregateRootTestCase extends TestCase
 
     abstract protected function aggregateRootClassName(): string;
 
-    abstract protected function commandHandler(AggregateRootRepository $repository, Clock $clock): CommandHandler;
-
     /**
      * @return $this
      */
@@ -119,10 +115,15 @@ abstract class AggregateRootTestCase extends TestCase
     /**
      * @return $this
      */
-    protected function when(Command $command)
+    protected function when()
     {
         try {
-            $this->commandHandler->handle($command);
+            if ( ! method_exists($this, 'handle')) {
+                throw new LogicException(sprintf('Class %s is missing a ::handle method.', get_class($this)));
+            }
+
+            $arguments = func_get_args();
+            $this->handle(...$arguments);
         } catch (Exception $exception) {
             $this->caughtException = $exception;
         }
@@ -181,6 +182,11 @@ abstract class AggregateRootTestCase extends TestCase
     protected function pointInTime(): PointInTime
     {
         return $this->clock->pointInTime();
+    }
+
+    protected function clock(): Clock
+    {
+        return $this->clock;
     }
 
     protected function messageDispatcher(): MessageDispatcher

--- a/src/AggregateRootTestCase.php
+++ b/src/AggregateRootTestCase.php
@@ -62,8 +62,10 @@ abstract class AggregateRootTestCase extends TestCase
         $className = $this->aggregateRootClassName();
         $this->clock = new TestClock();
         $this->aggregateRootId = $this->aggregateRootId();
-        $this->messageRepository = new InMemoryMessageRepository($this->messageDispatcher());
-        $this->repository = new AggregateRootRepository($className, $this->messageRepository, new DelegatingMessageDecorator());
+        $this->messageRepository = new InMemoryMessageRepository();
+        $dispatcher = $this->messageDispatcher();
+        $decorator = $this->messageDecorator();
+        $this->repository = new AggregateRootRepository($className, $this->messageRepository, $dispatcher, $decorator);
         $this->expectedEvents = [];
         $this->assertedScenario = false;
         $this->theExpectedException = null;
@@ -199,5 +201,10 @@ abstract class AggregateRootTestCase extends TestCase
     protected function consumers(): array
     {
         return [];
+    }
+
+    private function messageDecorator(): MessageDecorator
+    {
+        return new DelegatingMessageDecorator();
     }
 }

--- a/src/AggregateRootTestCase.php
+++ b/src/AggregateRootTestCase.php
@@ -115,14 +115,13 @@ abstract class AggregateRootTestCase extends TestCase
     /**
      * @return $this
      */
-    protected function when()
+    protected function when(... $arguments)
     {
         try {
             if ( ! method_exists($this, 'handle')) {
                 throw new LogicException(sprintf('Class %s is missing a ::handle method.', get_class($this)));
             }
 
-            $arguments = func_get_args();
             $this->handle(...$arguments);
         } catch (Exception $exception) {
             $this->caughtException = $exception;

--- a/src/AggregateRootTestCase.php
+++ b/src/AggregateRootTestCase.php
@@ -105,10 +105,15 @@ abstract class AggregateRootTestCase extends TestCase
      */
     protected function given(Event ... $events)
     {
-        $this->repository->persistEvents(... $events);
+        $this->repository->persistEvents($this->aggregateRootId(), ... $events);
         $this->messageRepository->purgeLastCommit();
 
         return $this;
+    }
+
+    public function on(AggregateRootId $id)
+    {
+        return new EventStager($id, $this->messageRepository, $this->repository, $this);
     }
 
     /**

--- a/src/CodeGeneration/CodeDumper.php
+++ b/src/CodeGeneration/CodeDumper.php
@@ -86,11 +86,6 @@ EOF;
         $fields = $this->fieldsFromDefinition($definition);
         $code = [];
         $code[] = <<<EOF
-    /**
-     * @var AggregateRootId
-     */
-    private \$aggregateRootId;
-
 
 EOF;
 
@@ -115,8 +110,8 @@ EOF;
 
     private function dumpEventConstructor(EventDefinition $event): string
     {
-        $arguments = ['        AggregateRootId $aggregateRootId', '        PointInTime $timeOfRecording'];
-        $assignments = ['        $this->aggregateRootId = $aggregateRootId;', '        $this->timeOfRecording = $timeOfRecording;'];
+        $arguments = ['        PointInTime $timeOfRecording'];
+        $assignments = ['        $this->timeOfRecording = $timeOfRecording;'];
         $fields = $this->fieldsFromDefinition($event);
 
         foreach ($fields as $field) {
@@ -142,8 +137,8 @@ EOF;
 
     private function dumpCommandConstructor(CommandDefinition $command): string
     {
-        $arguments = ['        AggregateRootId $aggregateRootId', '        PointInTime $timeOfRequest'];
-        $assignments = ['        $this->aggregateRootId = $aggregateRootId;', '        $this->timeOfRequest = $timeOfRequest;'];
+        $arguments = ['        PointInTime $timeOfRequest'];
+        $assignments = ['        $this->timeOfRequest = $timeOfRequest;'];
         $fields = $this->fieldsFromDefinition($command);
 
         foreach ($fields as $field) {
@@ -229,11 +224,9 @@ EOF;
         return <<<EOF
     public static function fromPayload(
         array \$payload,
-        AggregateRootId \$aggregateRootId,
         PointInTime \$timeOfRecording): Event
     {
         return new $name(
-            \$aggregateRootId,
             \$timeOfRecording$arguments
         );
     }
@@ -252,8 +245,8 @@ EOF;
     private function dumpTestHelpers(EventDefinition $event): string
     {
         $constructor = [];
-        $constructorArguments = 'AggregateRootId $aggregateRootId, PointInTime $timeOfRecording';
-        $constructorValues = ['$aggregateRootId', '$timeOfRecording'];
+        $constructorArguments = 'PointInTime $timeOfRecording';
+        $constructorValues = ['$timeOfRecording'];
         $helpers = [];
 
         foreach ($this->fieldsFromDefinition($event) as $field) {

--- a/src/CodeGeneration/CodeDumper.php
+++ b/src/CodeGeneration/CodeDumper.php
@@ -31,7 +31,6 @@ class CodeDumper
 
 namespace $namespace;
 
-use EventSauce\\EventSourcing\\AggregateRootId;
 use EventSauce\\EventSourcing\\Event;
 use EventSauce\\EventSourcing\\PointInTime;
 
@@ -163,15 +162,6 @@ EOF;
     private function dumpMethods(DefinitionWithFields $command): string
     {
         $methods = [];
-        $methods[] = <<<EOF
-    public function aggregateRootId(): AggregateRootId
-    {
-        return \$this->aggregateRootId;
-    }
-
-
-EOF;
-
 
         foreach ($this->fieldsFromDefinition($command) as $field) {
             $methods[] = <<<EOF
@@ -184,7 +174,7 @@ EOF;
 EOF;
         }
 
-        return rtrim(join('', $methods)) . "\n\n";
+        return empty($methods) ? '' : rtrim(join('', $methods)) . "\n\n";
     }
 
     private function dumpSerializationMethods(EventDefinition $event)

--- a/src/CodeGeneration/CodeDumper.php
+++ b/src/CodeGeneration/CodeDumper.php
@@ -32,7 +32,6 @@ class CodeDumper
 namespace $namespace;
 
 use EventSauce\\EventSourcing\\AggregateRootId;
-use EventSauce\\EventSourcing\\Command;
 use EventSauce\\EventSourcing\\Event;
 use EventSauce\\EventSourcing\\PointInTime;
 
@@ -314,7 +313,7 @@ EOF;
 
         foreach ($commands as $command) {
             $code[] = <<<EOF
-final class {$command->name()} implements Command
+final class {$command->name()}
 {
     /**
      * @var PointInTime

--- a/src/CodeGeneration/CodeDumperTest.php
+++ b/src/CodeGeneration/CodeDumperTest.php
@@ -20,7 +20,7 @@ class CodeDumperTest extends TestCase
             list ($definitionGroup, $fixtureFile) = $group;
             $dumper = new CodeDumper();
             $actual = $dumper->dump($definitionGroup);
-            // file_put_contents(__DIR__ . '/Fixtures/' . $fixtureFile . 'Fixture.php', $actual);
+            file_put_contents(__DIR__ . '/Fixtures/' . $fixtureFile . 'Fixture.php', $actual);
             $expected = file_get_contents(__DIR__ . '/Fixtures/' . $fixtureFile . 'Fixture.php');
             $this->assertEquals($expected, $actual, "Expect {$fixtureFile} to match generated code.");
         }

--- a/src/CodeGeneration/CodeDumperTest.php
+++ b/src/CodeGeneration/CodeDumperTest.php
@@ -20,7 +20,7 @@ class CodeDumperTest extends TestCase
             list ($definitionGroup, $fixtureFile) = $group;
             $dumper = new CodeDumper();
             $actual = $dumper->dump($definitionGroup);
-            file_put_contents(__DIR__ . '/Fixtures/' . $fixtureFile . 'Fixture.php', $actual);
+            // file_put_contents(__DIR__ . '/Fixtures/' . $fixtureFile . 'Fixture.php', $actual);
             $expected = file_get_contents(__DIR__ . '/Fixtures/' . $fixtureFile . 'Fixture.php');
             $this->assertEquals($expected, $actual, "Expect {$fixtureFile} to match generated code.");
         }

--- a/src/CodeGeneration/Fixtures/definedWithYamlFixture.php
+++ b/src/CodeGeneration/Fixtures/definedWithYamlFixture.php
@@ -3,7 +3,6 @@
 namespace DefinedWith\Yaml;
 
 use EventSauce\EventSourcing\AggregateRootId;
-use EventSauce\EventSourcing\Command;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 
@@ -168,7 +167,7 @@ final class VersionedEvent implements Event
 
 }
 
-final class HideFinancialDetailsOfFraudulentCompany implements Command
+final class HideFinancialDetailsOfFraudulentCompany
 {
     /**
      * @var PointInTime
@@ -205,7 +204,7 @@ final class HideFinancialDetailsOfFraudulentCompany implements Command
 
 }
 
-final class GoYamling implements Command
+final class GoYamling
 {
     /**
      * @var PointInTime

--- a/src/CodeGeneration/Fixtures/definedWithYamlFixture.php
+++ b/src/CodeGeneration/Fixtures/definedWithYamlFixture.php
@@ -10,11 +10,6 @@ use EventSauce\EventSourcing\PointInTime;
 final class WeWentYamling implements Event
 {
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var \Ramsey\Uuid\UuidInterface
      */
     private $reference;
@@ -30,12 +25,10 @@ final class WeWentYamling implements Event
     private $timeOfRecording;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording,
         \Ramsey\Uuid\UuidInterface $reference,
         string $slogan
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRecording = $timeOfRecording;
         $this->reference = $reference;
         $this->slogan = $slogan;
@@ -63,11 +56,9 @@ final class WeWentYamling implements Event
 
     public static function fromPayload(
         array $payload,
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording): Event
     {
         return new WeWentYamling(
-            $aggregateRootId,
             $timeOfRecording,
             \Ramsey\Uuid\Uuid::fromString($payload['reference']),
             (string) $payload['slogan']
@@ -93,10 +84,9 @@ final class WeWentYamling implements Event
         return $this;
     }
 
-    public static function withSlogan(AggregateRootId $aggregateRootId, PointInTime $timeOfRecording, string $slogan): WeWentYamling
+    public static function withSlogan(PointInTime $timeOfRecording, string $slogan): WeWentYamling
     {
         return new WeWentYamling(
-            $aggregateRootId,
             $timeOfRecording,
             \Ramsey\Uuid\Uuid::fromString("c0b47bc5-2aaa-497b-83cb-11d97da03a95"),
             $slogan
@@ -108,11 +98,6 @@ final class WeWentYamling implements Event
 final class VersionedEvent implements Event
 {
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var string
      */
     private $title;
@@ -123,11 +108,9 @@ final class VersionedEvent implements Event
     private $timeOfRecording;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording,
         string $title
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRecording = $timeOfRecording;
         $this->title = $title;
     }
@@ -149,11 +132,9 @@ final class VersionedEvent implements Event
 
     public static function fromPayload(
         array $payload,
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording): Event
     {
         return new VersionedEvent(
-            $aggregateRootId,
             $timeOfRecording,
             (string) $payload['title']
         );
@@ -177,10 +158,9 @@ final class VersionedEvent implements Event
         return $this;
     }
 
-    public static function with(AggregateRootId $aggregateRootId, PointInTime $timeOfRecording): VersionedEvent
+    public static function with(PointInTime $timeOfRecording): VersionedEvent
     {
         return new VersionedEvent(
-            $aggregateRootId,
             $timeOfRecording,
             (string) 'Some Example Title'
         );
@@ -196,21 +176,14 @@ final class HideFinancialDetailsOfFraudulentCompany implements Command
     private $timeOfRequest;
 
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var \Ramsey\Uuid\UuidInterface
      */
     private $companyId;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRequest,
         \Ramsey\Uuid\UuidInterface $companyId
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRequest = $timeOfRequest;
         $this->companyId = $companyId;
     }
@@ -240,11 +213,6 @@ final class GoYamling implements Command
     private $timeOfRequest;
 
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var \Ramsey\Uuid\UuidInterface
      */
     private $reference;
@@ -255,12 +223,10 @@ final class GoYamling implements Command
     private $slogan;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRequest,
         \Ramsey\Uuid\UuidInterface $reference,
         string $slogan
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRequest = $timeOfRequest;
         $this->reference = $reference;
         $this->slogan = $slogan;

--- a/src/CodeGeneration/Fixtures/definedWithYamlFixture.php
+++ b/src/CodeGeneration/Fixtures/definedWithYamlFixture.php
@@ -2,7 +2,6 @@
 
 namespace DefinedWith\Yaml;
 
-use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 
@@ -31,11 +30,6 @@ final class WeWentYamling implements Event
         $this->timeOfRecording = $timeOfRecording;
         $this->reference = $reference;
         $this->slogan = $slogan;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
     }
 
     public function reference(): \Ramsey\Uuid\UuidInterface
@@ -114,11 +108,6 @@ final class VersionedEvent implements Event
         $this->title = $title;
     }
 
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
-    }
-
     public function title(): string
     {
         return $this->title;
@@ -192,11 +181,6 @@ final class HideFinancialDetailsOfFraudulentCompany
         return $this->timeOfRequest;
     }
 
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
-    }
-
     public function companyId(): \Ramsey\Uuid\UuidInterface
     {
         return $this->companyId;
@@ -234,11 +218,6 @@ final class GoYamling
     public function timeOfRequest(): PointInTime
     {
         return $this->timeOfRequest;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
     }
 
     public function reference(): \Ramsey\Uuid\UuidInterface

--- a/src/CodeGeneration/Fixtures/definedWithoutHelpersInYamlFixture.php
+++ b/src/CodeGeneration/Fixtures/definedWithoutHelpersInYamlFixture.php
@@ -10,11 +10,6 @@ use EventSauce\EventSourcing\PointInTime;
 final class UserSubscribedFromMailingList implements Event
 {
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var string
      */
     private $username;
@@ -30,12 +25,10 @@ final class UserSubscribedFromMailingList implements Event
     private $timeOfRecording;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording,
         string $username,
         string $mailingList
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRecording = $timeOfRecording;
         $this->username = $username;
         $this->mailingList = $mailingList;
@@ -63,11 +56,9 @@ final class UserSubscribedFromMailingList implements Event
 
     public static function fromPayload(
         array $payload,
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording): Event
     {
         return new UserSubscribedFromMailingList(
-            $aggregateRootId,
             $timeOfRecording,
             (string) $payload['username'],
             (string) $payload['mailingList']
@@ -93,11 +84,6 @@ final class SubscribeToMailingList implements Command
     private $timeOfRequest;
 
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var string
      */
     private $username;
@@ -108,12 +94,10 @@ final class SubscribeToMailingList implements Command
     private $mailingList;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRequest,
         string $username,
         string $mailingList
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRequest = $timeOfRequest;
         $this->username = $username;
         $this->mailingList = $mailingList;
@@ -149,11 +133,6 @@ final class UnsubscribeFromMailingList implements Command
     private $timeOfRequest;
 
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var string
      */
     private $username;
@@ -169,13 +148,11 @@ final class UnsubscribeFromMailingList implements Command
     private $reason;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRequest,
         string $username,
         string $mailingList,
         string $reason
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRequest = $timeOfRequest;
         $this->username = $username;
         $this->mailingList = $mailingList;

--- a/src/CodeGeneration/Fixtures/definedWithoutHelpersInYamlFixture.php
+++ b/src/CodeGeneration/Fixtures/definedWithoutHelpersInYamlFixture.php
@@ -2,7 +2,6 @@
 
 namespace Acme\BusinessProcess;
 
-use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 
@@ -31,11 +30,6 @@ final class UserSubscribedFromMailingList implements Event
         $this->timeOfRecording = $timeOfRecording;
         $this->username = $username;
         $this->mailingList = $mailingList;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
     }
 
     public function username(): string
@@ -107,11 +101,6 @@ final class SubscribeToMailingList
         return $this->timeOfRequest;
     }
 
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
-    }
-
     public function username(): string
     {
         return $this->username;
@@ -161,11 +150,6 @@ final class UnsubscribeFromMailingList
     public function timeOfRequest(): PointInTime
     {
         return $this->timeOfRequest;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
     }
 
     public function username(): string

--- a/src/CodeGeneration/Fixtures/definedWithoutHelpersInYamlFixture.php
+++ b/src/CodeGeneration/Fixtures/definedWithoutHelpersInYamlFixture.php
@@ -3,7 +3,6 @@
 namespace Acme\BusinessProcess;
 
 use EventSauce\EventSourcing\AggregateRootId;
-use EventSauce\EventSourcing\Command;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 
@@ -76,7 +75,7 @@ final class UserSubscribedFromMailingList implements Event
 
 }
 
-final class SubscribeToMailingList implements Command
+final class SubscribeToMailingList
 {
     /**
      * @var PointInTime
@@ -125,7 +124,7 @@ final class SubscribeToMailingList implements Command
 
 }
 
-final class UnsubscribeFromMailingList implements Command
+final class UnsubscribeFromMailingList
 {
     /**
      * @var PointInTime

--- a/src/CodeGeneration/Fixtures/definitionGroupWithCommandFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithCommandFixture.php
@@ -3,11 +3,10 @@
 namespace With\Commands;
 
 use EventSauce\EventSourcing\AggregateRootId;
-use EventSauce\EventSourcing\Command;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 
-final class DoSomething implements Command
+final class DoSomething
 {
     /**
      * @var PointInTime

--- a/src/CodeGeneration/Fixtures/definitionGroupWithCommandFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithCommandFixture.php
@@ -15,21 +15,14 @@ final class DoSomething implements Command
     private $timeOfRequest;
 
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var string
      */
     private $reason;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRequest,
         string $reason
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRequest = $timeOfRequest;
         $this->reason = $reason;
     }

--- a/src/CodeGeneration/Fixtures/definitionGroupWithCommandFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithCommandFixture.php
@@ -2,7 +2,6 @@
 
 namespace With\Commands;
 
-use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 
@@ -29,11 +28,6 @@ final class DoSomething
     public function timeOfRequest(): PointInTime
     {
         return $this->timeOfRequest;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
     }
 
     public function reason(): string

--- a/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsFixture.php
@@ -3,7 +3,6 @@
 namespace Group\With\Defaults;
 
 use EventSauce\EventSourcing\AggregateRootId;
-use EventSauce\EventSourcing\Command;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 

--- a/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsFixture.php
@@ -10,11 +10,6 @@ use EventSauce\EventSourcing\PointInTime;
 final class EventWithDescription implements Event
 {
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var string
      */
     private $description;
@@ -25,11 +20,9 @@ final class EventWithDescription implements Event
     private $timeOfRecording;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording,
         string $description
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRecording = $timeOfRecording;
         $this->description = $description;
     }
@@ -51,11 +44,9 @@ final class EventWithDescription implements Event
 
     public static function fromPayload(
         array $payload,
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording): Event
     {
         return new EventWithDescription(
-            $aggregateRootId,
             $timeOfRecording,
             (string) $payload['description']
         );
@@ -79,10 +70,9 @@ final class EventWithDescription implements Event
         return $this;
     }
 
-    public static function with(AggregateRootId $aggregateRootId, PointInTime $timeOfRecording): EventWithDescription
+    public static function with(PointInTime $timeOfRecording): EventWithDescription
     {
         return new EventWithDescription(
-            $aggregateRootId,
             $timeOfRecording,
             (string) 'This is a description.'
         );

--- a/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsFixture.php
@@ -2,7 +2,6 @@
 
 namespace Group\With\Defaults;
 
-use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 
@@ -24,11 +23,6 @@ final class EventWithDescription implements Event
     ) {
         $this->timeOfRecording = $timeOfRecording;
         $this->description = $description;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
     }
 
     public function description(): string

--- a/src/CodeGeneration/Fixtures/definitionWithFieldsFromOtherDefinitionsFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionWithFieldsFromOtherDefinitionsFixture.php
@@ -3,7 +3,6 @@
 namespace EventsFrom\OtherTypes;
 
 use EventSauce\EventSourcing\AggregateRootId;
-use EventSauce\EventSourcing\Command;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 
@@ -117,7 +116,7 @@ final class ExtendedEvent implements Event
 
 }
 
-final class BaseCommand implements Command
+final class BaseCommand
 {
     /**
      * @var PointInTime
@@ -154,7 +153,7 @@ final class BaseCommand implements Command
 
 }
 
-final class ExtendedCommand implements Command
+final class ExtendedCommand
 {
     /**
      * @var PointInTime

--- a/src/CodeGeneration/Fixtures/definitionWithFieldsFromOtherDefinitionsFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionWithFieldsFromOtherDefinitionsFixture.php
@@ -2,7 +2,6 @@
 
 namespace EventsFrom\OtherTypes;
 
-use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 
@@ -24,11 +23,6 @@ final class BaseEvent implements Event
     ) {
         $this->timeOfRecording = $timeOfRecording;
         $this->age = $age;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
     }
 
     public function age(): int
@@ -79,11 +73,6 @@ final class ExtendedEvent implements Event
     ) {
         $this->timeOfRecording = $timeOfRecording;
         $this->age = $age;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
     }
 
     public function age(): int
@@ -141,11 +130,6 @@ final class BaseCommand
         return $this->timeOfRequest;
     }
 
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
-    }
-
     public function name(): string
     {
         return $this->name;
@@ -176,11 +160,6 @@ final class ExtendedCommand
     public function timeOfRequest(): PointInTime
     {
         return $this->timeOfRequest;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
     }
 
     public function name(): string

--- a/src/CodeGeneration/Fixtures/definitionWithFieldsFromOtherDefinitionsFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionWithFieldsFromOtherDefinitionsFixture.php
@@ -10,11 +10,6 @@ use EventSauce\EventSourcing\PointInTime;
 final class BaseEvent implements Event
 {
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var int
      */
     private $age;
@@ -25,11 +20,9 @@ final class BaseEvent implements Event
     private $timeOfRecording;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording,
         int $age
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRecording = $timeOfRecording;
         $this->age = $age;
     }
@@ -51,11 +44,9 @@ final class BaseEvent implements Event
 
     public static function fromPayload(
         array $payload,
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording): Event
     {
         return new BaseEvent(
-            $aggregateRootId,
             $timeOfRecording,
             (int) $payload['age']
         );
@@ -74,11 +65,6 @@ final class BaseEvent implements Event
 final class ExtendedEvent implements Event
 {
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var int
      */
     private $age;
@@ -89,11 +75,9 @@ final class ExtendedEvent implements Event
     private $timeOfRecording;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording,
         int $age
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRecording = $timeOfRecording;
         $this->age = $age;
     }
@@ -115,11 +99,9 @@ final class ExtendedEvent implements Event
 
     public static function fromPayload(
         array $payload,
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording): Event
     {
         return new ExtendedEvent(
-            $aggregateRootId,
             $timeOfRecording,
             (int) $payload['age']
         );
@@ -143,21 +125,14 @@ final class BaseCommand implements Command
     private $timeOfRequest;
 
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var string
      */
     private $name;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRequest,
         string $name
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRequest = $timeOfRequest;
         $this->name = $name;
     }
@@ -187,21 +162,14 @@ final class ExtendedCommand implements Command
     private $timeOfRequest;
 
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var string
      */
     private $name;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRequest,
         string $name
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRequest = $timeOfRequest;
         $this->name = $name;
     }

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationFixture.php
@@ -2,7 +2,6 @@
 
 namespace Group\With\FieldDeserialization;
 
-use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 
@@ -24,11 +23,6 @@ final class WithFieldSerializers implements Event
     ) {
         $this->timeOfRecording = $timeOfRecording;
         $this->items = $items;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
     }
 
     public function items(): array

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationFixture.php
@@ -3,7 +3,6 @@
 namespace Group\With\FieldDeserialization;
 
 use EventSauce\EventSourcing\AggregateRootId;
-use EventSauce\EventSourcing\Command;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationFixture.php
@@ -10,11 +10,6 @@ use EventSauce\EventSourcing\PointInTime;
 final class WithFieldSerializers implements Event
 {
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var array
      */
     private $items;
@@ -25,11 +20,9 @@ final class WithFieldSerializers implements Event
     private $timeOfRecording;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording,
         array $items
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRecording = $timeOfRecording;
         $this->items = $items;
     }
@@ -51,11 +44,9 @@ final class WithFieldSerializers implements Event
 
     public static function fromPayload(
         array $payload,
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording): Event
     {
         return new WithFieldSerializers(
-            $aggregateRootId,
             $timeOfRecording,
             array_map(function ($property) {
                 return ['property' => $property];
@@ -73,10 +64,9 @@ final class WithFieldSerializers implements Event
         ];
     }
 
-    public static function withItems(AggregateRootId $aggregateRootId, PointInTime $timeOfRecording, array $items): WithFieldSerializers
+    public static function withItems(PointInTime $timeOfRecording, array $items): WithFieldSerializers
     {
         return new WithFieldSerializers(
-            $aggregateRootId,
             $timeOfRecording,
             $items
         );

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventFixture.php
@@ -10,11 +10,6 @@ use EventSauce\EventSourcing\PointInTime;
 final class EventName implements Event
 {
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var string
      */
     private $title;
@@ -25,11 +20,9 @@ final class EventName implements Event
     private $timeOfRecording;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording,
         string $title
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRecording = $timeOfRecording;
         $this->title = $title;
     }
@@ -51,11 +44,9 @@ final class EventName implements Event
 
     public static function fromPayload(
         array $payload,
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording): Event
     {
         return new EventName(
-            $aggregateRootId,
             $timeOfRecording,
             strtolower($payload['title'])
         );
@@ -79,10 +70,9 @@ final class EventName implements Event
         return $this;
     }
 
-    public static function with(AggregateRootId $aggregateRootId, PointInTime $timeOfRecording): EventName
+    public static function with(PointInTime $timeOfRecording): EventName
     {
         return new EventName(
-            $aggregateRootId,
             $timeOfRecording,
             strtolower('Title')
         );

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventFixture.php
@@ -2,7 +2,6 @@
 
 namespace With\EventFieldSerialization;
 
-use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 
@@ -24,11 +23,6 @@ final class EventName implements Event
     ) {
         $this->timeOfRecording = $timeOfRecording;
         $this->title = $title;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
     }
 
     public function title(): string

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventFixture.php
@@ -3,7 +3,6 @@
 namespace With\EventFieldSerialization;
 
 use EventSauce\EventSourcing\AggregateRootId;
-use EventSauce\EventSourcing\Command;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 

--- a/src/CodeGeneration/Fixtures/groupWithVersionEventFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithVersionEventFixture.php
@@ -2,7 +2,6 @@
 
 namespace With\Versioned\Event;
 
-use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 
@@ -17,11 +16,6 @@ final class VersionTwo implements Event
         PointInTime $timeOfRecording
     ) {
         $this->timeOfRecording = $timeOfRecording;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
     }
 
     public function timeOfRecording(): PointInTime

--- a/src/CodeGeneration/Fixtures/groupWithVersionEventFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithVersionEventFixture.php
@@ -3,7 +3,6 @@
 namespace With\Versioned\Event;
 
 use EventSauce\EventSourcing\AggregateRootId;
-use EventSauce\EventSourcing\Command;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 

--- a/src/CodeGeneration/Fixtures/groupWithVersionEventFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithVersionEventFixture.php
@@ -10,20 +10,13 @@ use EventSauce\EventSourcing\PointInTime;
 final class VersionTwo implements Event
 {
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var PointInTime
      */
     private $timeOfRecording;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRecording = $timeOfRecording;
     }
 
@@ -39,11 +32,9 @@ final class VersionTwo implements Event
 
     public static function fromPayload(
         array $payload,
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording): Event
     {
         return new VersionTwo(
-            $aggregateRootId,
             $timeOfRecording
         );
     }
@@ -55,10 +46,9 @@ final class VersionTwo implements Event
         ];
     }
 
-    public static function with(AggregateRootId $aggregateRootId, PointInTime $timeOfRecording): VersionTwo
+    public static function with(PointInTime $timeOfRecording): VersionTwo
     {
         return new VersionTwo(
-            $aggregateRootId,
             $timeOfRecording
         );
     }

--- a/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupFixture.php
+++ b/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupFixture.php
@@ -10,11 +10,6 @@ use EventSauce\EventSourcing\PointInTime;
 final class FirstEvent implements Event
 {
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var string
      */
     private $firstField;
@@ -25,11 +20,9 @@ final class FirstEvent implements Event
     private $timeOfRecording;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording,
         string $firstField
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRecording = $timeOfRecording;
         $this->firstField = $firstField;
     }
@@ -51,11 +44,9 @@ final class FirstEvent implements Event
 
     public static function fromPayload(
         array $payload,
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording): Event
     {
         return new FirstEvent(
-            $aggregateRootId,
             $timeOfRecording,
             (string) $payload['firstField']
         );
@@ -79,10 +70,9 @@ final class FirstEvent implements Event
         return $this;
     }
 
-    public static function with(AggregateRootId $aggregateRootId, PointInTime $timeOfRecording): FirstEvent
+    public static function with(PointInTime $timeOfRecording): FirstEvent
     {
         return new FirstEvent(
-            $aggregateRootId,
             $timeOfRecording,
             (string) 'FIRST'
         );
@@ -92,11 +82,6 @@ final class FirstEvent implements Event
 
 final class SecondEvent implements Event
 {
-    /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
     /**
      * @var string
      */
@@ -108,11 +93,9 @@ final class SecondEvent implements Event
     private $timeOfRecording;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording,
         string $secondField
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRecording = $timeOfRecording;
         $this->secondField = $secondField;
     }
@@ -134,11 +117,9 @@ final class SecondEvent implements Event
 
     public static function fromPayload(
         array $payload,
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording): Event
     {
         return new SecondEvent(
-            $aggregateRootId,
             $timeOfRecording,
             (string) $payload['secondField']
         );
@@ -162,10 +143,9 @@ final class SecondEvent implements Event
         return $this;
     }
 
-    public static function with(AggregateRootId $aggregateRootId, PointInTime $timeOfRecording): SecondEvent
+    public static function with(PointInTime $timeOfRecording): SecondEvent
     {
         return new SecondEvent(
-            $aggregateRootId,
             $timeOfRecording,
             (string) 'SECOND'
         );

--- a/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupFixture.php
+++ b/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupFixture.php
@@ -2,7 +2,6 @@
 
 namespace Multiple\Events\DefinitionGroup;
 
-use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 
@@ -24,11 +23,6 @@ final class FirstEvent implements Event
     ) {
         $this->timeOfRecording = $timeOfRecording;
         $this->firstField = $firstField;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
     }
 
     public function firstField(): string
@@ -97,11 +91,6 @@ final class SecondEvent implements Event
     ) {
         $this->timeOfRecording = $timeOfRecording;
         $this->secondField = $secondField;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
     }
 
     public function secondField(): string

--- a/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupFixture.php
+++ b/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupFixture.php
@@ -3,7 +3,6 @@
 namespace Multiple\Events\DefinitionGroup;
 
 use EventSauce\EventSourcing\AggregateRootId;
-use EventSauce\EventSourcing\Command;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 

--- a/src/CodeGeneration/Fixtures/simpleDefinitionGroupFixture.php
+++ b/src/CodeGeneration/Fixtures/simpleDefinitionGroupFixture.php
@@ -2,7 +2,6 @@
 
 namespace Simple\Definition\Group;
 
-use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 
@@ -31,11 +30,6 @@ final class SomethingHappened implements Event
         $this->timeOfRecording = $timeOfRecording;
         $this->what = $what;
         $this->yolo = $yolo;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
     }
 
     public function what(): string

--- a/src/CodeGeneration/Fixtures/simpleDefinitionGroupFixture.php
+++ b/src/CodeGeneration/Fixtures/simpleDefinitionGroupFixture.php
@@ -3,7 +3,6 @@
 namespace Simple\Definition\Group;
 
 use EventSauce\EventSourcing\AggregateRootId;
-use EventSauce\EventSourcing\Command;
 use EventSauce\EventSourcing\Event;
 use EventSauce\EventSourcing\PointInTime;
 

--- a/src/CodeGeneration/Fixtures/simpleDefinitionGroupFixture.php
+++ b/src/CodeGeneration/Fixtures/simpleDefinitionGroupFixture.php
@@ -10,11 +10,6 @@ use EventSauce\EventSourcing\PointInTime;
 final class SomethingHappened implements Event
 {
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var string
      */
     private $what;
@@ -30,12 +25,10 @@ final class SomethingHappened implements Event
     private $timeOfRecording;
 
     public function __construct(
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording,
         string $what,
         bool $yolo
     ) {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRecording = $timeOfRecording;
         $this->what = $what;
         $this->yolo = $yolo;
@@ -63,11 +56,9 @@ final class SomethingHappened implements Event
 
     public static function fromPayload(
         array $payload,
-        AggregateRootId $aggregateRootId,
         PointInTime $timeOfRecording): Event
     {
         return new SomethingHappened(
-            $aggregateRootId,
             $timeOfRecording,
             (string) $payload['what'],
             (bool) $payload['yolo']
@@ -103,10 +94,9 @@ final class SomethingHappened implements Event
         return $this;
     }
 
-    public static function with(AggregateRootId $aggregateRootId, PointInTime $timeOfRecording): SomethingHappened
+    public static function with(PointInTime $timeOfRecording): SomethingHappened
     {
         return new SomethingHappened(
-            $aggregateRootId,
             $timeOfRecording,
             (string) 'Example Event',
             (bool) true

--- a/src/CodeGeneration/YamlDefinitionLoaderTest.php
+++ b/src/CodeGeneration/YamlDefinitionLoaderTest.php
@@ -21,7 +21,7 @@ class YamlDefinitionLoaderTest extends TestCase
         $definitionGroup = $loader->load(__DIR__ . '/Fixtures/exampleDefinition.yaml');
         $dumper = new CodeDumper();
         $code = $dumper->dump($definitionGroup);
-        // file_put_contents(__DIR__ . '/Fixtures/definedWithYamlFixture.php', $code);
+        file_put_contents(__DIR__ . '/Fixtures/definedWithYamlFixture.php', $code);
         $expected = file_get_contents(__DIR__ . '/Fixtures/definedWithYamlFixture.php');
         $this->assertEquals($expected, $code);
     }
@@ -35,7 +35,7 @@ class YamlDefinitionLoaderTest extends TestCase
         $definitionGroup = $loader->load(__DIR__ . '/Fixtures/exampleDefinitionWithoutHelpers.yaml');
         $dumper = new CodeDumper();
         $code = $dumper->dump($definitionGroup, false);
-        // file_put_contents(__DIR__ . '/Fixtures/definedWithoutHelpersInYamlFixture.php', $code);
+        file_put_contents(__DIR__ . '/Fixtures/definedWithoutHelpersInYamlFixture.php', $code);
         $expected = file_get_contents(__DIR__ . '/Fixtures/definedWithoutHelpersInYamlFixture.php');
         $this->assertEquals($expected, $code);
     }
@@ -49,6 +49,7 @@ class YamlDefinitionLoaderTest extends TestCase
         $definitionGroup = $loader->load(__DIR__ . '/Fixtures/definitionWithFieldsFromOtherDefinitions.yaml');
         $dumper = new CodeDumper();
         $code = $dumper->dump($definitionGroup, false);
+        file_put_contents(__DIR__ . '/Fixtures/definitionWithFieldsFromOtherDefinitionsFixture.php', $code);
         $expected = file_get_contents(__DIR__ . '/Fixtures/definitionWithFieldsFromOtherDefinitionsFixture.php');
         $this->assertEquals($expected, $code);
     }

--- a/src/CodeGeneration/YamlDefinitionLoaderTest.php
+++ b/src/CodeGeneration/YamlDefinitionLoaderTest.php
@@ -21,7 +21,7 @@ class YamlDefinitionLoaderTest extends TestCase
         $definitionGroup = $loader->load(__DIR__ . '/Fixtures/exampleDefinition.yaml');
         $dumper = new CodeDumper();
         $code = $dumper->dump($definitionGroup);
-        file_put_contents(__DIR__ . '/Fixtures/definedWithYamlFixture.php', $code);
+        // file_put_contents(__DIR__ . '/Fixtures/definedWithYamlFixture.php', $code);
         $expected = file_get_contents(__DIR__ . '/Fixtures/definedWithYamlFixture.php');
         $this->assertEquals($expected, $code);
     }
@@ -35,7 +35,7 @@ class YamlDefinitionLoaderTest extends TestCase
         $definitionGroup = $loader->load(__DIR__ . '/Fixtures/exampleDefinitionWithoutHelpers.yaml');
         $dumper = new CodeDumper();
         $code = $dumper->dump($definitionGroup, false);
-        file_put_contents(__DIR__ . '/Fixtures/definedWithoutHelpersInYamlFixture.php', $code);
+        // file_put_contents(__DIR__ . '/Fixtures/definedWithoutHelpersInYamlFixture.php', $code);
         $expected = file_get_contents(__DIR__ . '/Fixtures/definedWithoutHelpersInYamlFixture.php');
         $this->assertEquals($expected, $code);
     }
@@ -49,7 +49,7 @@ class YamlDefinitionLoaderTest extends TestCase
         $definitionGroup = $loader->load(__DIR__ . '/Fixtures/definitionWithFieldsFromOtherDefinitions.yaml');
         $dumper = new CodeDumper();
         $code = $dumper->dump($definitionGroup, false);
-        file_put_contents(__DIR__ . '/Fixtures/definitionWithFieldsFromOtherDefinitionsFixture.php', $code);
+        // file_put_contents(__DIR__ . '/Fixtures/definitionWithFieldsFromOtherDefinitionsFixture.php', $code);
         $expected = file_get_contents(__DIR__ . '/Fixtures/definitionWithFieldsFromOtherDefinitionsFixture.php');
         $this->assertEquals($expected, $code);
     }

--- a/src/Command.php
+++ b/src/Command.php
@@ -1,8 +1,0 @@
-<?php
-
-
-namespace EventSauce\EventSourcing;
-
-interface Command
-{
-}

--- a/src/Command.php
+++ b/src/Command.php
@@ -5,5 +5,4 @@ namespace EventSauce\EventSourcing;
 
 interface Command
 {
-    public function aggregateRootId(): AggregateRootId;
 }

--- a/src/CommandHandler.php
+++ b/src/CommandHandler.php
@@ -1,9 +1,0 @@
-<?php
-
-
-namespace EventSauce\EventSourcing;
-
-interface CommandHandler
-{
-    public function handle(Command $command);
-}

--- a/src/Event.php
+++ b/src/Event.php
@@ -7,11 +7,9 @@ interface Event
 {
     const EVENT_VERSION_PAYLOAD_KEY = '__event_version';
 
-    public function aggregateRootId(): AggregateRootId;
-
     public function timeOfRecording(): PointInTime;
 
     public function toPayload(): array;
 
-    public static function fromPayload(array $payload, AggregateRootId $aggregateRootId, PointInTime $timeOfRecording): Event;
+    public static function fromPayload(array $payload, PointInTime $timeOfRecording): Event;
 }

--- a/src/EventStager.php
+++ b/src/EventStager.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace EventSauce\EventSourcing;
+
+class EventStager
+{
+    /**
+     * @var AggregateRootId
+     */
+    private $id;
+
+    /**
+     * @var AggregateRootRepository
+     */
+    private $repository;
+
+    /**
+     * @var AggregateRootTestCase
+     */
+    private $testCase;
+
+    /**
+     * @var InMemoryMessageRepository
+     */
+    private $messageRepository;
+
+    public function __construct(AggregateRootId $id, InMemoryMessageRepository $messageRepository, AggregateRootRepository $repository, AggregateRootTestCase $testCase)
+    {
+        $this->id = $id;
+        $this->repository = $repository;
+        $this->testCase = $testCase;
+        $this->messageRepository = $messageRepository;
+    }
+
+    /**
+     * @return AggregateRootTestCase
+     */
+    public function stage(Event ... $events): AggregateRootTestCase
+    {
+        $this->repository->persistEvents($this->id, ... $events);
+        $this->messageRepository->purgeLastCommit();
+
+        return $this->testCase;
+    }
+}

--- a/src/InMemoryMessageRepository.php
+++ b/src/InMemoryMessageRepository.php
@@ -14,18 +14,7 @@ class InMemoryMessageRepository implements MessageRepository
     /**
      * @var Event[]
      */
-    private $lastCommit;
-
-    /**
-     * @var MessageDispatcher
-     */
-    private $dispatcher;
-
-    public function __construct(MessageDispatcher $dispatcher = null)
-    {
-        $this->lastCommit = [];
-        $this->dispatcher = $dispatcher ?: new SynchronousMessageDispatcher();
-    }
+    private $lastCommit = [];
 
     /**
      * @return Event[]
@@ -50,8 +39,6 @@ class InMemoryMessageRepository implements MessageRepository
             $this->messages[$id->toString()][] = $message;
             $this->lastCommit[] = $event;
         }
-
-        $this->dispatcher->dispatch(... $messages);
     }
 
     public function retrieveAll(AggregateRootId $id): Generator

--- a/src/InMemoryMessageRepository.php
+++ b/src/InMemoryMessageRepository.php
@@ -40,14 +40,14 @@ class InMemoryMessageRepository implements MessageRepository
         $this->lastCommit = [];
     }
 
-    public function persist(Message ... $messages)
+    public function persist(AggregateRootId $id, Message ... $messages)
     {
         $this->lastCommit = [];
 
         /** @var Message $event */
         foreach ($messages as $message) {
             $event = $message->event();
-            $this->messages[$message->aggregateRootId()->toString()][] = $message;
+            $this->messages[$id->toString()][] = $message;
             $this->lastCommit[] = $event;
         }
 

--- a/src/Integration/DecoratingMessages/DummyDecoratedEvent.php
+++ b/src/Integration/DecoratingMessages/DummyDecoratedEvent.php
@@ -11,16 +11,6 @@ use EventSauce\EventSourcing\PointInTime;
  */
 class DummyDecoratedEvent implements Event
 {
-    public function aggregateRootId(): AggregateRootId
-    {
-
-    }
-
-    public function eventVersion(): int
-    {
-
-    }
-
     public function timeOfRecording(): PointInTime
     {
 
@@ -31,7 +21,7 @@ class DummyDecoratedEvent implements Event
 
     }
 
-    public static function fromPayload(array $payload, AggregateRootId $aggregateRootId, PointInTime $timeOfRecording): Event
+    public static function fromPayload(array $payload, PointInTime $timeOfRecording): Event
     {
 
     }

--- a/src/Integration/DecoratingMessages/MessageDecoratingTest.php
+++ b/src/Integration/DecoratingMessages/MessageDecoratingTest.php
@@ -4,6 +4,7 @@ namespace EventSauce\EventSourcing\Integration\DecoratingMessages;
 
 use EventSauce\EventSourcing\DelegatingMessageDecorator;
 use EventSauce\EventSourcing\Message;
+use EventSauce\EventSourcing\UuidAggregateRootId;
 use PHPUnit\Framework\TestCase;
 
 class MessageDecoratingTest extends TestCase
@@ -13,9 +14,10 @@ class MessageDecoratingTest extends TestCase
      */
     public function decorating_messages()
     {
+        $id = UuidAggregateRootId::create();
         $decorator = new DelegatingMessageDecorator(new DummyMessageDecorator());
         $event = new DummyDecoratedEvent();
-        $message = new Message($event);
+        $message = new Message($id, $event);
         $decoratedMessage = $decorator->decorate($message);
         $this->assertEquals($event, $decoratedMessage->event());
         $this->assertEquals('value', $decoratedMessage->metadataValue('dummy'));

--- a/src/Integration/SynchronousDispatching/SynchronousEventStub.php
+++ b/src/Integration/SynchronousDispatching/SynchronousEventStub.php
@@ -11,16 +11,6 @@ use EventSauce\EventSourcing\PointInTime;
  */
 class SynchronousEventStub implements Event
 {
-    public function aggregateRootId(): AggregateRootId
-    {
-
-    }
-
-    public function eventVersion(): int
-    {
-
-    }
-
     public function timeOfRecording(): PointInTime
     {
 
@@ -31,7 +21,7 @@ class SynchronousEventStub implements Event
 
     }
 
-    public static function fromPayload(array $payload, AggregateRootId $aggregateRootId, PointInTime $timeOfRecording): Event
+    public static function fromPayload(array $payload, PointInTime $timeOfRecording): Event
     {
 
     }

--- a/src/Integration/SynchronousDispatching/SynchronousMessageDispatcherTest.php
+++ b/src/Integration/SynchronousDispatching/SynchronousMessageDispatcherTest.php
@@ -4,6 +4,7 @@ namespace EventSauce\EventSourcing\Integration\SynchronousDispatching;
 
 use EventSauce\EventSourcing\Message;
 use EventSauce\EventSourcing\SynchronousMessageDispatcher;
+use EventSauce\EventSourcing\UuidAggregateRootId;
 use PHPUnit\Framework\TestCase;
 
 class SynchronousMessageDispatcherTest extends TestCase
@@ -13,9 +14,10 @@ class SynchronousMessageDispatcherTest extends TestCase
      */
     public function dispatching_messages_synchronously()
     {
+        $aggregateRootId = UuidAggregateRootId::create();
         $stubconsumer = new SynchronousConsumerStub();
         $syncDispatcher = new SynchronousMessageDispatcher($stubconsumer, $stubconsumer);
-        $message = new Message(new SynchronousEventStub());
+        $message = new Message($aggregateRootId, new SynchronousEventStub());
         $syncDispatcher->dispatch($message, $message);
         $this->assertEquals([$message, $message, $message, $message], $stubconsumer->handled);
     }

--- a/src/Integration/TestingAggregates/DummyAggregate.php
+++ b/src/Integration/TestingAggregates/DummyAggregate.php
@@ -12,7 +12,6 @@ class DummyAggregate extends BaseAggregateRoot
     public function performDummyTask(Clock $clock)
     {
         $this->recordThat(new DummyTaskWasExecuted(
-            $this->aggregateRootId(),
             $clock->pointInTime()
         ));
     }
@@ -20,7 +19,6 @@ class DummyAggregate extends BaseAggregateRoot
     public function increment(Clock $clock)
     {
         $this->recordThat(new DummyIncrementingHappened(
-            $this->aggregateRootId(),
             $clock->pointInTime(),
             $this->incrementedNumber + 1
         ));

--- a/src/Integration/TestingAggregates/DummyCommand.php
+++ b/src/Integration/TestingAggregates/DummyCommand.php
@@ -3,9 +3,8 @@
 namespace EventSauce\EventSourcing\Integration\TestingAggregates;
 
 use EventSauce\EventSourcing\AggregateRootId;
-use EventSauce\EventSourcing\Command;
 
-class DummyCommand implements Command
+class DummyCommand
 {
     /**
      * @var AggregateRootId

--- a/src/Integration/TestingAggregates/DummyCommandHandler.php
+++ b/src/Integration/TestingAggregates/DummyCommandHandler.php
@@ -3,13 +3,9 @@
 namespace EventSauce\EventSourcing\Integration\TestingAggregates;
 
 use EventSauce\EventSourcing\AggregateRootRepository;
-use EventSauce\EventSourcing\Command;
-use EventSauce\EventSourcing\CommandHandler;
 use EventSauce\EventSourcing\Time\Clock;
-use LogicException;
-use function method_exists;
 
-class DummyCommandHandler implements CommandHandler
+class DummyCommandHandler
 {
     /**
      * @var AggregateRootRepository
@@ -31,7 +27,7 @@ class DummyCommandHandler implements CommandHandler
      * @param DummyCommand $command
      * @throws DummyException
      */
-    public function handle(Command $command)
+    public function handle($command)
     {
         /** @var DummyAggregate $aggregate */
         $aggregate = $this->repository->retrieve($command->aggregateRootId());

--- a/src/Integration/TestingAggregates/DummyCommandHandler.php
+++ b/src/Integration/TestingAggregates/DummyCommandHandler.php
@@ -6,6 +6,8 @@ use EventSauce\EventSourcing\AggregateRootRepository;
 use EventSauce\EventSourcing\Command;
 use EventSauce\EventSourcing\CommandHandler;
 use EventSauce\EventSourcing\Time\Clock;
+use LogicException;
+use function method_exists;
 
 class DummyCommandHandler implements CommandHandler
 {
@@ -25,6 +27,10 @@ class DummyCommandHandler implements CommandHandler
         $this->clock = $clock;
     }
 
+    /**
+     * @param DummyCommand $command
+     * @throws DummyException
+     */
     public function handle(Command $command)
     {
         /** @var DummyAggregate $aggregate */

--- a/src/Integration/TestingAggregates/DummyIncrementCommand.php
+++ b/src/Integration/TestingAggregates/DummyIncrementCommand.php
@@ -3,9 +3,8 @@
 namespace EventSauce\EventSourcing\Integration\TestingAggregates;
 
 use EventSauce\EventSourcing\AggregateRootId;
-use EventSauce\EventSourcing\Command;
 
-class DummyIncrementCommand implements Command
+class DummyIncrementCommand
 {
     /**
      * @var AggregateRootId

--- a/src/Integration/TestingAggregates/DummyIncrementingHappened.php
+++ b/src/Integration/TestingAggregates/DummyIncrementingHappened.php
@@ -12,11 +12,6 @@ use EventSauce\EventSourcing\PointInTime;
 class DummyIncrementingHappened implements Event
 {
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var PointInTime
      */
     private $timeOfRecording;
@@ -26,21 +21,10 @@ class DummyIncrementingHappened implements Event
      */
     private $number;
 
-    public function __construct(AggregateRootId $aggregateRootId, PointInTime $timeOfRecording, int $number)
+    public function __construct(PointInTime $timeOfRecording, int $number)
     {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRecording = $timeOfRecording;
         $this->number = $number;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
-    }
-
-    public function eventVersion(): int
-    {
-        return 1;
     }
 
     public function timeOfRecording(): PointInTime
@@ -53,9 +37,9 @@ class DummyIncrementingHappened implements Event
         return [];
     }
 
-    public static function fromPayload(array $payload, AggregateRootId $aggregateRootId, PointInTime $timeOfRecording): Event
+    public static function fromPayload(array $payload, PointInTime $timeOfRecording): Event
     {
-        return new DummyIncrementingHappened($aggregateRootId, $timeOfRecording, $payload['number']);
+        return new DummyIncrementingHappened($timeOfRecording, $payload['number']);
     }
 
     public function number(): int

--- a/src/Integration/TestingAggregates/DummyTaskWasExecuted.php
+++ b/src/Integration/TestingAggregates/DummyTaskWasExecuted.php
@@ -11,25 +11,15 @@ use EventSauce\EventSourcing\PointInTime;
  */
 class DummyTaskWasExecuted implements Event
 {
-    /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
 
     /**
      * @var PointInTime
      */
     private $timeOfRecording;
 
-    public function __construct(AggregateRootId $aggregateRootId, PointInTime $timeOfRecording)
+    public function __construct(PointInTime $timeOfRecording)
     {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRecording = $timeOfRecording;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
     }
 
     public function eventVersion(): int
@@ -47,8 +37,8 @@ class DummyTaskWasExecuted implements Event
         return [];
     }
 
-    public static function fromPayload(array $payload, AggregateRootId $aggregateRootId, PointInTime $timeOfRecording): Event
+    public static function fromPayload(array $payload, PointInTime $timeOfRecording): Event
     {
-        return new DummyTaskWasExecuted($aggregateRootId, $timeOfRecording);
+        return new DummyTaskWasExecuted($timeOfRecording);
     }
 }

--- a/src/Integration/TestingAggregates/ExampleAggregateRootTest.php
+++ b/src/Integration/TestingAggregates/ExampleAggregateRootTest.php
@@ -29,7 +29,7 @@ class ExampleAggregateRootTest extends AggregateRootTestCase
     {
         $aggregateRootId = $this->aggregateRootId();
         $this->when(new DummyCommand($aggregateRootId));
-        $this->then(new DummyTaskWasExecuted($aggregateRootId, $this->pointInTime()));
+        $this->then(new DummyTaskWasExecuted($this->pointInTime()));
     }
 
     /**
@@ -78,9 +78,22 @@ class ExampleAggregateRootTest extends AggregateRootTestCase
     public function setting_preconditions()
     {
         $id = $this->aggregateRootId();
-        $this->given(new DummyIncrementingHappened($id, $this->pointInTime(), 1))
+        $this->given(new DummyIncrementingHappened($this->pointInTime(), 1))
             ->when(new DummyIncrementCommand($id))
-            ->then(new DummyIncrementingHappened($id, $this->pointInTime(), 2));
+            ->then(new DummyIncrementingHappened($this->pointInTime(), 2));
+    }
+
+    /**
+     * @test
+     */
+    public function setting_preconditions_from_other_aggregates()
+    {
+        $id = $this->aggregateRootId();
+        $this->on(UuidAggregateRootId::create())->stage(
+            new DummyIncrementingHappened($this->pointInTime(), 10)
+        )
+            ->when(new DummyIncrementCommand($id))
+            ->then(new DummyIncrementingHappened($this->pointInTime(), 1));
     }
 
     protected function aggregateRootId(): AggregateRootId

--- a/src/Integration/TestingAggregates/ExampleAggregateRootTest.php
+++ b/src/Integration/TestingAggregates/ExampleAggregateRootTest.php
@@ -5,7 +5,6 @@ namespace EventSauce\EventSourcing\Integration\TestingAggregates;
 use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\AggregateRootRepository;
 use EventSauce\EventSourcing\AggregateRootTestCase;
-use EventSauce\EventSourcing\CommandHandler;
 use EventSauce\EventSourcing\Time\Clock;
 use EventSauce\EventSourcing\UuidAggregateRootId;
 use LogicException;
@@ -17,7 +16,7 @@ class ExampleAggregateRootTest extends AggregateRootTestCase
         return DummyAggregate::class;
     }
 
-    protected function commandHandler(AggregateRootRepository $repository, Clock $clock): CommandHandler
+    protected function commandHandler(AggregateRootRepository $repository, Clock $clock)
     {
         return new DummyCommandHandler($repository, $clock);
     }
@@ -94,6 +93,12 @@ class ExampleAggregateRootTest extends AggregateRootTestCase
         )
             ->when(new DummyIncrementCommand($id))
             ->then(new DummyIncrementingHappened($this->pointInTime(), 1));
+    }
+
+    protected function handle($command)
+    {
+        $commandHandler = $this->commandHandler($this->repository, $this->clock());
+        $commandHandler->handle($command);
     }
 
     protected function aggregateRootId(): AggregateRootId

--- a/src/Integration/TestingAggregates/ExceptionInducingCommand.php
+++ b/src/Integration/TestingAggregates/ExceptionInducingCommand.php
@@ -3,9 +3,8 @@
 namespace EventSauce\EventSourcing\Integration\TestingAggregates;
 
 use EventSauce\EventSourcing\AggregateRootId;
-use EventSauce\EventSourcing\Command;
 
-class ExceptionInducingCommand implements Command
+class ExceptionInducingCommand
 {
     /**
      * @var AggregateRootId

--- a/src/Integration/TestingAggregates/IgnoredCommand.php
+++ b/src/Integration/TestingAggregates/IgnoredCommand.php
@@ -3,9 +3,8 @@
 namespace EventSauce\EventSourcing\Integration\TestingAggregates;
 
 use EventSauce\EventSourcing\AggregateRootId;
-use EventSauce\EventSourcing\Command;
 
-class IgnoredCommand implements Command
+class IgnoredCommand
 {
     /**
      * @var AggregateRootId

--- a/src/Integration/Upcasting/UpcastedEventStub.php
+++ b/src/Integration/Upcasting/UpcastedEventStub.php
@@ -9,11 +9,6 @@ use EventSauce\EventSourcing\PointInTime;
 class UpcastedEventStub implements Event
 {
     /**
-     * @var AggregateRootId
-     */
-    private $aggregateRootId;
-
-    /**
      * @var PointInTime
      */
     private $timeOfRecording;
@@ -23,16 +18,10 @@ class UpcastedEventStub implements Event
      */
     private $property;
 
-    public function __construct(AggregateRootId $aggregateRootId, PointInTime $timeOfRecording, string $property)
+    public function __construct(PointInTime $timeOfRecording, string $property)
     {
-        $this->aggregateRootId = $aggregateRootId;
         $this->timeOfRecording = $timeOfRecording;
         $this->property = $property;
-    }
-
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
     }
 
     public function timeOfRecording(): PointInTime
@@ -45,8 +34,8 @@ class UpcastedEventStub implements Event
         return ['property' => $this->property, self::EVENT_VERSION_PAYLOAD_KEY => 1];
     }
 
-    public static function fromPayload(array $payload, AggregateRootId $aggregateRootId, PointInTime $timeOfRecording): Event
+    public static function fromPayload(array $payload, PointInTime $timeOfRecording): Event
     {
-        return new UpcastedEventStub($aggregateRootId, $timeOfRecording, $payload['property'] ?? 'undefined');
+        return new UpcastedEventStub($timeOfRecording, $payload['property'] ?? 'undefined');
     }
 }

--- a/src/Integration/Upcasting/UpcastingEventsTest.php
+++ b/src/Integration/Upcasting/UpcastingEventsTest.php
@@ -21,11 +21,12 @@ class UpcastingEventsTest extends TestCase
     {
         $clock = new TestClock();
         $pointInTime = $clock->pointInTime();
+        $aggregateRootId = UuidAggregateRootId::create();
 
         $payload = [
             'type'            => (new DotSeparatedSnakeCaseInflector())->classNameToEventName(UpcastedEventStub::class),
             'version'         => 0,
-            'aggregateRootId' => $uuid = UuidAggregateRootId::create()->toString(),
+            'aggregateRootId' => $aggregateRootId->toString(),
             'timeOfRecording' => $pointInTime->toString(),
             'metadata'        => [],
             'data'            => [],
@@ -35,8 +36,7 @@ class UpcastingEventsTest extends TestCase
         $serializer = new UpcastingMessageSerializer(new ConstructingMessageSerializer(UuidAggregateRootId::class), $upcaster);
 
         $message = iterator_to_array($serializer->unserializePayload($payload))[0];
-        $expected = new Message(new UpcastedEventStub(
-            new UuidAggregateRootId($uuid),
+        $expected = new Message($aggregateRootId, new UpcastedEventStub(
             $pointInTime,
             'upcasted'
         ));
@@ -47,7 +47,7 @@ class UpcastingEventsTest extends TestCase
         $expectedPayload = $payload = [
             'type'            => (new DotSeparatedSnakeCaseInflector())->classNameToEventName(UpcastedEventStub::class),
             'version'         => 1,
-            'aggregateRootId' => $uuid,
+            'aggregateRootId' => $aggregateRootId->toString(),
             'timeOfRecording' => $pointInTime->toString(),
             'metadata'        => [],
             'data'            => [

--- a/src/Message.php
+++ b/src/Message.php
@@ -14,15 +14,21 @@ final class Message
      */
     private $metadata;
 
-    public function __construct(Event $event, array $metadata = [])
+    /**
+     * @var AggregateRootId
+     */
+    private $aggregateRootId;
+
+    public function __construct(AggregateRootId $aggregateRootId, Event $event, array $metadata = [])
     {
         $this->event = $event;
         $this->metadata = $metadata;
+        $this->aggregateRootId = $aggregateRootId;
     }
 
     public function aggregateRootId(): AggregateRootId
     {
-        return $this->event->aggregateRootId();
+        return $this->aggregateRootId;
     }
 
     public function withMetadata(string $key, $value)

--- a/src/MessageRepository.php
+++ b/src/MessageRepository.php
@@ -6,6 +6,6 @@ use Generator;
 
 interface MessageRepository
 {
-    public function persist(Message ... $messages);
+    public function persist(AggregateRootId $id, Message ... $messages);
     public function retrieveAll(AggregateRootId $id): Generator;
 }

--- a/src/Serialization/ConstructingMessageSerializer.php
+++ b/src/Serialization/ConstructingMessageSerializer.php
@@ -36,7 +36,7 @@ final class ConstructingMessageSerializer implements MessageSerializer
         return [
             'type' => $this->eventNameInflector->eventToEventName($event),
             'version' => $payload[Event::EVENT_VERSION_PAYLOAD_KEY] ?? 0,
-            'aggregateRootId' => $event->aggregateRootId()->toString(),
+            'aggregateRootId' => $message->aggregateRootId()->toString(),
             'timeOfRecording' => $event->timeOfRecording()->toString(),
             'metadata' => $message->metadata(),
             'data' => $payload,
@@ -49,12 +49,12 @@ final class ConstructingMessageSerializer implements MessageSerializer
         $className = $this->eventNameInflector->eventNameToClassName($payload['type']);
         /** @var AggregateRootId $aggregateRootIdClassName */
         $aggregateRootIdClassName = $this->aggregateRootIdClassName;
+        $aggregateRootId = $aggregateRootIdClassName::fromString($payload['aggregateRootId']);
         $event = $className::fromPayload(
             $payload['data'],
-            $aggregateRootIdClassName::fromString($payload['aggregateRootId']),
             PointInTime::fromString($payload['timeOfRecording'])
         );
 
-        yield new Message($event, $payload['metadata']);
+        yield new Message($aggregateRootId, $event, $payload['metadata']);
     }
 }


### PR DESCRIPTION
Removed the requirement for commands and events to be aware of the aggregate root id. Also removed the Command and Command handler. The base test case requires you to setup a handle method which can offload to anything.

