### PR TITLE
Enhancement: Enable no_alias_functions fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -10,6 +10,7 @@ return PhpCsFixer\Config::create()
         'binary_operator_spaces' => ['align_double_arrow' => true],
         'concat_space' => ['spacing' => 'one'],
         'declare_strict_types' => true,
+        'no_alias_functions' => true,
         'not_operator_with_space' => true,
     ])
     ->setRiskyAllowed(true)


### PR DESCRIPTION
❗️ Blocked by #29.

This PR

* [x] enables the `no_alias_functions` fixer

Related to https://github.com/EventSaucePHP/EventSauce/pull/29/commits/d3fdbe96eaeaeb6d70ead6c59ff4c9c67920d04f.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.10.4#usage:

>**no_alias_functions** [`@Symfony:risky`]
>
>Master functions shall be used instead of aliases.
>
>Risky rule: risky when any of the alias functions are overridden.