### PR TITLE
Remove redundant wording in sub header

### DIFF
--- a/docs/docs/event-sourcing.md
+++ b/docs/docs/event-sourcing.md
@@ -41,7 +41,7 @@ style of programming the focus is put on communication. Because we're
 primarily modelling using messages communicating change is very easy to
 facilitate.
 
-## The cost
+## The cost and trade-offs
 
 Event sourcing is one of the bigger paradigm shifts in software modelling.
 It is also not a cost-free solution. Like many things in our work-field,

--- a/docs/docs/event-sourcing.md
+++ b/docs/docs/event-sourcing.md
@@ -41,7 +41,7 @@ style of programming the focus is put on communication. Because we're
 primarily modelling using messages communicating change is very easy to
 facilitate.
 
-## The cost of event sourcing
+## The cost
 
 Event sourcing is one of the bigger paradigm shifts in software modelling.
 It is also not a cost-free solution. Like many things in our work-field,


### PR DESCRIPTION
It feels better to leave this part out as the next header also doesn't explicitly has it. Either it's included or left out in both but anything else feels a bit off.