### PR TITLE
Fixes #28: extracted an interface from the aggregate root repository.

### DIFF
--- a/src/AggregateRootRepository.php
+++ b/src/AggregateRootRepository.php
@@ -4,79 +4,11 @@ declare(strict_types=1);
 
 namespace EventSauce\EventSourcing;
 
-use Generator;
-
-final class AggregateRootRepository
+interface AggregateRootRepository
 {
-    /**
-     * @var string
-     */
-    private $aggregateRootClassName;
+    public function retrieve(AggregateRootId $aggregateRootId): object;
 
-    /**
-     * @var MessageRepository
-     */
-    private $repository;
+    public function persist(object $aggregateRoot);
 
-    /**
-     * @var MessageDecorator
-     */
-    private $decorator;
-
-    /**
-     * @var MessageDispatcher
-     */
-    private $dispatcher;
-
-    public function __construct(
-        string $aggregateRootClassName,
-        MessageRepository $messageRepository,
-        MessageDispatcher $dispatcher = null,
-        MessageDecorator $decorator = null
-    ) {
-        $this->aggregateRootClassName = $aggregateRootClassName;
-        $this->repository = $messageRepository;
-        $this->dispatcher = $dispatcher ?: new SynchronousMessageDispatcher();
-        $this->decorator = $decorator ?: new DefaultHeadersDecorator();
-    }
-
-    public function retrieve(AggregateRootId $aggregateRootId): AggregateRoot
-    {
-        /** @var AggregateRoot $className */
-        $className = $this->aggregateRootClassName;
-        $events = $this->retrieveAllEvents($aggregateRootId);
-
-        return $className::reconstituteFromEvents($aggregateRootId, $events);
-    }
-
-    private function retrieveAllEvents(AggregateRootId $aggregateRootId): Generator
-    {
-        /** @var Message $message */
-        foreach ($this->repository->retrieveAll($aggregateRootId) as $message) {
-            yield $message->event();
-        }
-    }
-
-    public function persist(AggregateRoot $aggregateRoot)
-    {
-        $this->persistEvents(
-            $aggregateRoot->aggregateRootId(),
-            $aggregateRoot->aggregateRootVersion(),
-            ...$aggregateRoot->releaseEvents()
-        );
-    }
-
-    public function persistEvents(AggregateRootId $aggregateRootId, int $aggregateRootVersion, object ...$events)
-    {
-        $metadata = [Header::AGGREGATE_ROOT_ID => $aggregateRootId];
-        $messages = array_map(function (object $event) use ($metadata, &$aggregateRootVersion) {
-            return $this->decorator->decorate(new Message(
-                $event,
-                $metadata + [Header::AGGREGATE_ROOT_VERSION => ++$aggregateRootVersion]
-            ));
-        }, $events);
-
-        $this->repository->persist(...$messages);
-        $this->dispatcher->dispatch(...$messages);
-    }
+    public function persistEvents(AggregateRootId $aggregateRootId, int $aggregateRootVersion, object ...$events);
 }

--- a/src/AggregateRootTestCase.php
+++ b/src/AggregateRootTestCase.php
@@ -70,7 +70,7 @@ abstract class AggregateRootTestCase extends TestCase
         $this->messageRepository = new InMemoryMessageRepository();
         $dispatcher = $this->messageDispatcher();
         $decorator = $this->messageDecorator();
-        $this->repository = new AggregateRootRepository(
+        $this->repository = $this->aggregateRootRepository(
             $className,
             $this->messageRepository,
             $dispatcher,
@@ -224,5 +224,19 @@ abstract class AggregateRootTestCase extends TestCase
     private function messageDecorator(): MessageDecorator
     {
         return new MessageDecoratorChain(new DefaultHeadersDecorator());
+    }
+
+    protected function aggregateRootRepository(
+        string $className,
+        MessageRepository $repository,
+        MessageDispatcher $dispatcher,
+        MessageDecorator $decorator
+    ): AggregateRootRepository {
+        return new ConstructingAggregateRootRepository(
+            $className,
+            $repository,
+            $dispatcher,
+            $decorator
+        );
     }
 }

--- a/src/ConstructingAggregateRootRepository.php
+++ b/src/ConstructingAggregateRootRepository.php
@@ -60,7 +60,7 @@ final class ConstructingAggregateRootRepository implements AggregateRootReposito
 
     public function persist(object $aggregateRoot)
     {
-        assert($aggregateRoot instanceof AggregateRoot, "Expected \$aggregateRoot to be an instance of " . AggregateRoot::class);
+        assert($aggregateRoot instanceof AggregateRoot, 'Expected $aggregateRoot to be an instance of ' . AggregateRoot::class);
 
         $this->persistEvents(
             $aggregateRoot->aggregateRootId(),

--- a/src/ConstructingAggregateRootRepository.php
+++ b/src/ConstructingAggregateRootRepository.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\EventSourcing;
+
+use function assert;
+use Generator;
+
+final class ConstructingAggregateRootRepository implements AggregateRootRepository
+{
+    /**
+     * @var string
+     */
+    private $aggregateRootClassName;
+
+    /**
+     * @var MessageRepository
+     */
+    private $repository;
+
+    /**
+     * @var MessageDecorator
+     */
+    private $decorator;
+
+    /**
+     * @var MessageDispatcher
+     */
+    private $dispatcher;
+
+    public function __construct(
+        string $aggregateRootClassName,
+        MessageRepository $messageRepository,
+        MessageDispatcher $dispatcher = null,
+        MessageDecorator $decorator = null
+    ) {
+        $this->aggregateRootClassName = $aggregateRootClassName;
+        $this->repository = $messageRepository;
+        $this->dispatcher = $dispatcher ?: new SynchronousMessageDispatcher();
+        $this->decorator = $decorator ?: new DefaultHeadersDecorator();
+    }
+
+    public function retrieve(AggregateRootId $aggregateRootId): object
+    {
+        /** @var AggregateRoot $className */
+        $className = $this->aggregateRootClassName;
+        $events = $this->retrieveAllEvents($aggregateRootId);
+
+        return $className::reconstituteFromEvents($aggregateRootId, $events);
+    }
+
+    private function retrieveAllEvents(AggregateRootId $aggregateRootId): Generator
+    {
+        /** @var Message $message */
+        foreach ($this->repository->retrieveAll($aggregateRootId) as $message) {
+            yield $message->event();
+        }
+    }
+
+    public function persist(object $aggregateRoot)
+    {
+        assert($aggregateRoot instanceof AggregateRoot, "Expected \$aggregateRoot to be an instance of " . AggregateRoot::class);
+
+        $this->persistEvents(
+            $aggregateRoot->aggregateRootId(),
+            $aggregateRoot->aggregateRootVersion(),
+            ...$aggregateRoot->releaseEvents()
+        );
+    }
+
+    public function persistEvents(AggregateRootId $aggregateRootId, int $aggregateRootVersion, object ...$events)
+    {
+        $metadata = [Header::AGGREGATE_ROOT_ID => $aggregateRootId];
+        $messages = array_map(function (object $event) use ($metadata, &$aggregateRootVersion) {
+            return $this->decorator->decorate(new Message(
+                $event,
+                $metadata + [Header::AGGREGATE_ROOT_VERSION => ++$aggregateRootVersion]
+            ));
+        }, $events);
+
+        $this->repository->persist(...$messages);
+        $this->dispatcher->dispatch(...$messages);
+    }
+}


### PR DESCRIPTION
This is an alternate implementation to achieve the same goal. In this implementation the aggregate root repository is converted into an interface and the default implementation is the `ConstructingAggregateRootRepository` which is a sane default implementation. This effectively turns the whole library into a reference implementation of itself.