### PR TITLE
Make PHPStorm stop annoying me

### DIFF
--- a/src/AggregateRoot.php
+++ b/src/AggregateRoot.php
@@ -19,7 +19,7 @@ interface AggregateRoot
     public function aggregateRootVersion(): int;
 
     /**
-     * @return object[]
+     * @return \object[]
      */
     public function releaseEvents(): array;
 

--- a/src/AggregateRootBehaviour/ConstructionBehaviour.php
+++ b/src/AggregateRootBehaviour/ConstructionBehaviour.php
@@ -42,7 +42,7 @@ trait ConstructionBehaviour
     {
         $aggregateRoot = new static($aggregateRootId);
 
-        /** @var object $event */
+        /** @var \object $event */
         foreach ($events as $event) {
             $aggregateRoot->apply($event);
             ++$aggregateRoot->aggregateRootVersion;

--- a/src/AggregateRootBehaviour/EventRecordingBehaviour.php
+++ b/src/AggregateRootBehaviour/EventRecordingBehaviour.php
@@ -7,7 +7,7 @@ namespace EventSauce\EventSourcing\AggregateRootBehaviour;
 trait EventRecordingBehaviour
 {
     /**
-     * @var object[]
+     * @var \object[]
      */
     private $recordedEvents = [];
 
@@ -18,7 +18,7 @@ trait EventRecordingBehaviour
     }
 
     /**
-     * @return object[]
+     * @return \object[]
      */
     public function releaseEvents(): array
     {

--- a/src/AggregateRootTestCase.php
+++ b/src/AggregateRootTestCase.php
@@ -35,7 +35,7 @@ abstract class AggregateRootTestCase extends TestCase
     private $caughtException;
 
     /**
-     * @var object[]
+     * @var \object[]
      */
     private $expectedEvents = [];
 

--- a/src/InMemoryMessageRepository.php
+++ b/src/InMemoryMessageRepository.php
@@ -14,12 +14,12 @@ class InMemoryMessageRepository implements MessageRepository
     private $messages = [];
 
     /**
-     * @var object[]
+     * @var \object[]
      */
     private $lastCommit = [];
 
     /**
-     * @return object[]
+     * @return \object[]
      */
     public function lastCommit(): array
     {

--- a/src/Message.php
+++ b/src/Message.php
@@ -7,7 +7,7 @@ namespace EventSauce\EventSourcing;
 final class Message
 {
     /**
-     * @var object
+     * @var \object
      */
     private $event;
 


### PR DESCRIPTION
PHPStorm thinks `object` should belong in the global namespace. I tend to agree