### PR TITLE
Update docs header to 0.5.0

### DIFF
--- a/docs/_data/project.yml
+++ b/docs/_data/project.yml
@@ -1,4 +1,4 @@
 title: "EventSauce"
 tagline: "No-nonsense event sourcing for PHP"
 description: "Event sourcing for PHP with easy test tooling."
-version: 0.4.0
+version: 0.5.0


### PR DESCRIPTION
I noticed the docs header still showed `0.4.0`. I think this is the place to fix that.
![image](https://user-images.githubusercontent.com/1141514/50798376-0845ed80-128d-11e9-99cf-b64a5effcd1e.png)
