### PR TITLE
Feature: codegen interfaces

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,7 @@
             <exclude>
                 <directory suffix="Test.php">src/</directory>
                 <directory suffix="Fixture.php">src/</directory>
+                <directory suffix=".php">src/CodeGeneration/Fixtures/</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/CodeGeneration/CodeDumper.php
+++ b/src/CodeGeneration/CodeDumper.php
@@ -8,10 +8,8 @@ use LogicException;
 use function array_filter;
 use function array_map;
 use function implode;
-use function join;
 use function sprintf;
 use function ucfirst;
-use function var_dump;
 use function var_export;
 use const null;
 
@@ -51,8 +49,9 @@ EOF;
 
     /**
      * @param PayloadDefinition[] $definitions
-     * @param bool  $withHelpers
-     * @param bool  $withSerialization
+     * @param bool                $withHelpers
+     * @param bool                $withSerialization
+     *
      * @return string
      */
     private function dumpClasses(array $definitions, bool $withHelpers, bool $withSerialization): string
@@ -75,7 +74,7 @@ EOF;
             if ($withSerialization) {
                 $interfaces[] = 'SerializablePayload';
             }
-            $implements = empty($interfaces) ? '' : ' implements ' . join(', ', $interfaces);
+            $implements = empty($interfaces) ? '' : ' implements ' . implode(', ', $interfaces);
 
             $allSections = [$fields, $constructor, $methods, $deserializer, $testHelpers];
             $allSections = array_filter(array_map('rtrim', $allSections));

--- a/src/CodeGeneration/CodeDumper.php
+++ b/src/CodeGeneration/CodeDumper.php
@@ -8,8 +8,10 @@ use LogicException;
 use function array_filter;
 use function array_map;
 use function implode;
+use function join;
 use function sprintf;
 use function ucfirst;
+use function var_dump;
 use function var_export;
 use const null;
 
@@ -26,6 +28,7 @@ class CodeDumper
         $definitionCode = $this->dumpClasses($definitionGroup->events(), $withHelpers, $withSerialization);
         $commandCode = $this->dumpClasses($definitionGroup->commands(), $withHelpers, $withSerialization);
         $namespace = $definitionGroup->namespace();
+
         $allCode = implode("\n\n", array_filter([$definitionCode, $commandCode]));
 
         if ($withSerialization) {
@@ -46,6 +49,12 @@ $allCode
 EOF;
     }
 
+    /**
+     * @param PayloadDefinition[] $definitions
+     * @param bool  $withHelpers
+     * @param bool  $withSerialization
+     * @return string
+     */
     private function dumpClasses(array $definitions, bool $withHelpers, bool $withSerialization): string
     {
         $code = [];
@@ -56,12 +65,17 @@ EOF;
 
         foreach ($definitions as $definition) {
             $name = $definition->name();
+            $interfaces = $definition->interfaces();
             $fields = $this->dumpFields($definition);
             $constructor = $this->dumpConstructor($definition);
             $methods = $this->dumpMethods($definition);
             $deserializer = $this->dumpSerializationMethods($definition);
             $testHelpers = $withHelpers ? $this->dumpTestHelpers($definition) : '';
-            $implements = $withSerialization ? ' implements SerializablePayload' : '';
+
+            if ($withSerialization) {
+                $interfaces[] = 'SerializablePayload';
+            }
+            $implements = empty($interfaces) ? '' : ' implements ' . join(', ', $interfaces);
 
             $allSections = [$fields, $constructor, $methods, $deserializer, $testHelpers];
             $allSections = array_filter(array_map('rtrim', $allSections));

--- a/src/CodeGeneration/DefinitionGroup.php
+++ b/src/CodeGeneration/DefinitionGroup.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace EventSauce\EventSourcing\CodeGeneration;
 
 use EventSauce\EventSourcing\PointInTime;
+use OutOfBoundsException;
+use function array_key_exists;
 
 final class DefinitionGroup
 {
@@ -66,6 +68,11 @@ final class DefinitionGroup
      * @var string[]
      */
     private $typeAliases = [];
+
+    /**
+     * @var string[]
+     */
+    private $interfaces = [];
 
     public function __construct()
     {
@@ -192,5 +199,19 @@ final class DefinitionGroup
     public function namespace(): string
     {
         return $this->namespace;
+    }
+
+    public function defineInterface(string $alias, string $interfaceName): void
+    {
+        $this->interfaces[$alias] = $interfaceName;
+    }
+
+    public function resolveInterface(string $alias): string
+    {
+        if ( ! array_key_exists($alias, $this->interfaces)) {
+            throw new OutOfBoundsException("Interface not registered for alias ${alias}.");
+        }
+
+        return $this->interfaces[$alias];
     }
 }

--- a/src/CodeGeneration/Fixtures/MarkerInterfaceStub.php
+++ b/src/CodeGeneration/Fixtures/MarkerInterfaceStub.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace EventSauce\EventSourcing\CodeGeneration\Fixtures;
+
+interface MarkerInterfaceStub
+{
+
+}

--- a/src/CodeGeneration/Fixtures/commands-with-interfaces.yaml
+++ b/src/CodeGeneration/Fixtures/commands-with-interfaces.yaml
@@ -1,0 +1,14 @@
+---
+namespace: CommandsWithInterfaces
+interfaces:
+  marker: EventSauce\EventSourcing\CodeGeneration\Fixtures\MarkerInterfaceStub
+
+commands:
+    CommandWithInterfaceMarker:
+        implements: marker
+    AlsoCommandWithInterfaceMarker:
+        implements:
+            - marker
+events:
+    EventWithInterfaceMarker:
+        implements: marker

--- a/src/CodeGeneration/Fixtures/commands-with-non-existing-interfaces.yaml
+++ b/src/CodeGeneration/Fixtures/commands-with-non-existing-interfaces.yaml
@@ -1,0 +1,5 @@
+---
+namespace: CommandsWithInterfaces
+commands:
+    CommandWithInterfaceMarker:
+        implements: marker

--- a/src/CodeGeneration/Fixtures/commandsWithInterfaces.php
+++ b/src/CodeGeneration/Fixtures/commandsWithInterfaces.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommandsWithInterfaces;
+
+use EventSauce\EventSourcing\Serialization\SerializablePayload;
+
+final class EventWithInterfaceMarker implements \EventSauce\EventSourcing\CodeGeneration\Fixtures\MarkerInterfaceStub, SerializablePayload
+{
+    public static function fromPayload(array $payload): SerializablePayload
+    {
+        return new EventWithInterfaceMarker();
+    }
+
+    public function toPayload(): array
+    {
+        return [];
+    }
+}
+
+final class CommandWithInterfaceMarker implements \EventSauce\EventSourcing\CodeGeneration\Fixtures\MarkerInterfaceStub, SerializablePayload
+{
+    public static function fromPayload(array $payload): SerializablePayload
+    {
+        return new CommandWithInterfaceMarker();
+    }
+
+    public function toPayload(): array
+    {
+        return [];
+    }
+}
+
+final class AlsoCommandWithInterfaceMarker implements \EventSauce\EventSourcing\CodeGeneration\Fixtures\MarkerInterfaceStub, SerializablePayload
+{
+    public static function fromPayload(array $payload): SerializablePayload
+    {
+        return new AlsoCommandWithInterfaceMarker();
+    }
+
+    public function toPayload(): array
+    {
+        return [];
+    }
+}

--- a/src/CodeGeneration/Fixtures/definedWithoutHelpersInYamlFixture.php
+++ b/src/CodeGeneration/Fixtures/definedWithoutHelpersInYamlFixture.php
@@ -51,39 +51,6 @@ final class UserSubscribedFromMailingList implements SerializablePayload
             'mailingList' => (string) $this->mailingList,
         ];
     }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public function withUsername(string $username): UserSubscribedFromMailingList
-    {
-        $clone = clone $this;
-        $clone->username = $username;
-
-        return $clone;
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public function withMailingList(string $mailingList): UserSubscribedFromMailingList
-    {
-        $clone = clone $this;
-        $clone->mailingList = $mailingList;
-
-        return $clone;
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public static function with(): UserSubscribedFromMailingList
-    {
-        return new UserSubscribedFromMailingList(
-            (string) 'example-user',
-            (string) 'list-name'
-        );
-    }
 }
 
 final class SubscribeToMailingList implements SerializablePayload
@@ -130,39 +97,6 @@ final class SubscribeToMailingList implements SerializablePayload
             'username' => (string) $this->username,
             'mailingList' => (string) $this->mailingList,
         ];
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public function withUsername(string $username): SubscribeToMailingList
-    {
-        $clone = clone $this;
-        $clone->username = $username;
-
-        return $clone;
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public function withMailingList(string $mailingList): SubscribeToMailingList
-    {
-        $clone = clone $this;
-        $clone->mailingList = $mailingList;
-
-        return $clone;
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public static function with(): SubscribeToMailingList
-    {
-        return new SubscribeToMailingList(
-            (string) 'example-user',
-            (string) 'list-name'
-        );
     }
 }
 
@@ -224,50 +158,5 @@ final class UnsubscribeFromMailingList implements SerializablePayload
             'mailingList' => (string) $this->mailingList,
             'reason' => (string) $this->reason,
         ];
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public function withUsername(string $username): UnsubscribeFromMailingList
-    {
-        $clone = clone $this;
-        $clone->username = $username;
-
-        return $clone;
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public function withMailingList(string $mailingList): UnsubscribeFromMailingList
-    {
-        $clone = clone $this;
-        $clone->mailingList = $mailingList;
-
-        return $clone;
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public function withReason(string $reason): UnsubscribeFromMailingList
-    {
-        $clone = clone $this;
-        $clone->reason = $reason;
-
-        return $clone;
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public static function with(): UnsubscribeFromMailingList
-    {
-        return new UnsubscribeFromMailingList(
-            (string) 'example-user',
-            (string) 'list-name',
-            (string) 'no-longer-interested'
-        );
     }
 }

--- a/src/CodeGeneration/Fixtures/non-existing-interface.yaml
+++ b/src/CodeGeneration/Fixtures/non-existing-interface.yaml
@@ -1,0 +1,4 @@
+---
+namespace: InterfacesDontExist
+interfaces:
+    marker: DoesNotExistInTheCodebase

--- a/src/CodeGeneration/PayloadDefinition.php
+++ b/src/CodeGeneration/PayloadDefinition.php
@@ -36,6 +36,11 @@ final class PayloadDefinition
      */
     private $fieldDeserializers = [];
 
+    /**
+     * @var string[]
+     */
+    private $interfaces = [];
+
     public function __construct(DefinitionGroup $group, string $name)
     {
         $this->name = $name;
@@ -47,9 +52,16 @@ final class PayloadDefinition
      *
      * @return $this
      */
-    public function withFieldsFrom(string $otherType)
+    public function withFieldsFrom(string $otherType): PayloadDefinition
     {
         $this->fieldsFrom = $otherType;
+
+        return $this;
+    }
+
+    public function withInterface(string $interface): PayloadDefinition
+    {
+        $this->interfaces[] = $interface;
 
         return $this;
     }
@@ -69,7 +81,7 @@ final class PayloadDefinition
         return $this->fieldsFrom;
     }
 
-    public function field(string $name, string $type, string $example = null)
+    public function field(string $name, string $type, string $example = null): PayloadDefinition
     {
         $example = $example ?: $this->group->exampleForField($name);
         $this->fields[] = compact('name', 'type', 'example');
@@ -77,7 +89,7 @@ final class PayloadDefinition
         return $this;
     }
 
-    public function fieldSerializer($field, $template)
+    public function fieldSerializer($field, $template): PayloadDefinition
     {
         $this->fieldSerializers[$field] = $template;
 
@@ -109,5 +121,10 @@ final class PayloadDefinition
     public function serializerForType($type)
     {
         return $this->group->serializerForType($type);
+    }
+
+    public function interfaces(): array
+    {
+        return $this->interfaces;
     }
 }

--- a/src/CodeGeneration/YamlDefinitionLoader.php
+++ b/src/CodeGeneration/YamlDefinitionLoader.php
@@ -8,8 +8,6 @@ use InvalidArgumentException;
 use LogicException;
 use function is_array;
 use Symfony\Component\Yaml\Yaml;
-use function strpos;
-use function var_dump;
 use const PATHINFO_EXTENSION;
 use function file_get_contents;
 use function in_array;
@@ -101,14 +99,14 @@ class YamlDefinitionLoader implements DefinitionLoader
         }
     }
 
-    private function loadInterfaces(DefinitionGroup $definitionGroup, array $interfaces)
+    private function loadInterfaces(DefinitionGroup $definitionGroup, array $interfaces): void
     {
         foreach ($interfaces as $alias => $interfaceName) {
             if ( ! interface_exists($interfaceName)) {
                 throw new LogicException("Interface {$interfaceName} does not exist.");
             }
 
-            $definitionGroup->defineInterface($alias, '\\'. ltrim($interfaceName, '\\'));
+            $definitionGroup->defineInterface($alias, '\\' . ltrim($interfaceName, '\\'));
         }
     }
 

--- a/src/CodeGeneration/YamlDefinitionLoaderTest.php
+++ b/src/CodeGeneration/YamlDefinitionLoaderTest.php
@@ -74,7 +74,7 @@ class YamlDefinitionLoaderTest extends TestCase
     /**
      * @test
      */
-    public function trying_to_use_non_existing_interfaces()
+    public function trying_to_use_non_existing_interfaces(): void
     {
         $this->expectException(LogicException::class);
         $loader = new YamlDefinitionLoader();


### PR DESCRIPTION
When using commands for system interaction, a common thing is to have the identifier of the aggregate as a field in all of your commands. In order to get easier autocompletion on those fields, interfaces can be used.

Given there's an interface:

```php
interface MarkerInterfaceName {
    public function id(): string;
}
```

You can generate commands and events with interfaces like this:

```yaml
---
namespace: SomeNamespace
interfaces:
  marker: MarkerInterfaceName

commands:
  CommandWithMarkerInterface:
    implements: marker
    fields:
      id: string
  AnotherCommandWithMarkerInterface:
    implements: marker
    fields:
      id: string
```

Then a command handler could just accept the interface:

```php
function handle(MarkerInterfaceName $command)
{
  $id = $command->id(); // Type checks out!
}
```

When using stuff like PHPStan, this will make your life a lot easier.