### PR TITLE
Feature: Event Consumer

### DIFF
--- a/src/EventConsumer.php
+++ b/src/EventConsumer.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\EventSourcing;
+
+abstract class EventConsumer implements Consumer
+{
+    public function handle(Message $message): void
+    {
+        $event = $message->event();
+        $parts = explode('\\', get_class($event));
+        $method = 'handle'.end($parts);
+
+        if (method_exists($this, $method)) {
+            $this->{$method}($event, $message);
+        }
+    }
+}

--- a/src/EventConsumer.php
+++ b/src/EventConsumer.php
@@ -10,7 +10,7 @@ abstract class EventConsumer implements Consumer
     {
         $event = $message->event();
         $parts = explode('\\', get_class($event));
-        $method = 'handle'.end($parts);
+        $method = 'handle' . end($parts);
 
         if (method_exists($this, $method)) {
             $this->{$method}($event, $message);

--- a/src/Integration/EventConsumption/DummyEventForConsuming.php
+++ b/src/Integration/EventConsumption/DummyEventForConsuming.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing\Integration\EventConsumption;
 
 class DummyEventForConsuming

--- a/src/Integration/EventConsumption/DummyEventForConsuming.php
+++ b/src/Integration/EventConsumption/DummyEventForConsuming.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace EventSauce\EventSourcing\Integration\EventConsumption;
+
+class DummyEventForConsuming
+{
+    /**
+     * @var string
+     */
+    private $message;
+
+    public function __construct(string $message)
+    {
+        $this->message = $message;
+    }
+
+    public function message(): string
+    {
+        return $this->message;
+    }
+}

--- a/src/Integration/EventConsumption/EventConsumerStub.php
+++ b/src/Integration/EventConsumption/EventConsumerStub.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing\Integration\EventConsumption;
 
 use EventSauce\EventSourcing\EventConsumer;
@@ -10,7 +12,7 @@ class EventConsumerStub extends EventConsumer
     public $message = '';
     public $messageObject = null;
 
-    protected function handleDummyEventForConsuming(DummyEventForConsuming $event, Message $message)
+    protected function handleDummyEventForConsuming(DummyEventForConsuming $event, Message $message): void
     {
         $this->message = $event->message();
         $this->messageObject = $message;

--- a/src/Integration/EventConsumption/EventConsumerStub.php
+++ b/src/Integration/EventConsumption/EventConsumerStub.php
@@ -3,13 +3,16 @@
 namespace EventSauce\EventSourcing\Integration\EventConsumption;
 
 use EventSauce\EventSourcing\EventConsumer;
+use EventSauce\EventSourcing\Message;
 
 class EventConsumerStub extends EventConsumer
 {
     public $message = '';
+    public $messageObject = null;
 
-    protected function handleDummyEventForConsuming(DummyEventForConsuming $event)
+    protected function handleDummyEventForConsuming(DummyEventForConsuming $event, Message $message)
     {
         $this->message = $event->message();
+        $this->messageObject = $message;
     }
 }

--- a/src/Integration/EventConsumption/EventConsumerStub.php
+++ b/src/Integration/EventConsumption/EventConsumerStub.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace EventSauce\EventSourcing\Integration\EventConsumption;
+
+use EventSauce\EventSourcing\EventConsumer;
+
+class EventConsumerStub extends EventConsumer
+{
+    public $message = '';
+
+    protected function handleDummyEventForConsuming(DummyEventForConsuming $event)
+    {
+        $this->message = $event->message();
+    }
+}

--- a/src/Integration/EventConsumption/EventConsumerTest.php
+++ b/src/Integration/EventConsumption/EventConsumerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace EventSauce\EventSourcing\Integration\EventConsumption;
+
+use EventSauce\EventSourcing\Message;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class EventConsumerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function handling_an_event()
+    {
+        $consumer = new EventConsumerStub();
+        $message = new Message(new DummyEventForConsuming('Sup.'));
+        $consumer->handle(new Message(new stdClass()));
+        $this->assertEquals('', $consumer->message);
+        $consumer->handle($message);
+        $this->assertEquals('Sup.', $consumer->message);
+    }
+}

--- a/src/Integration/EventConsumption/EventConsumerTest.php
+++ b/src/Integration/EventConsumption/EventConsumerTest.php
@@ -19,5 +19,8 @@ class EventConsumerTest extends TestCase
         $this->assertEquals('', $consumer->message);
         $consumer->handle($message);
         $this->assertEquals('Sup.', $consumer->message);
+        $this->assertEquals($message, $consumer->messageObject);
     }
+
+
 }

--- a/src/Integration/EventConsumption/EventConsumerTest.php
+++ b/src/Integration/EventConsumption/EventConsumerTest.php
@@ -21,6 +21,4 @@ class EventConsumerTest extends TestCase
         $this->assertEquals('Sup.', $consumer->message);
         $this->assertEquals($message, $consumer->messageObject);
     }
-
-
 }

--- a/src/Integration/EventConsumption/EventConsumerTest.php
+++ b/src/Integration/EventConsumption/EventConsumerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing\Integration\EventConsumption;
 
 use EventSauce\EventSourcing\Message;
@@ -11,7 +13,7 @@ class EventConsumerTest extends TestCase
     /**
      * @test
      */
-    public function handling_an_event()
+    public function handling_an_event(): void
     {
         $consumer = new EventConsumerStub();
         $message = new Message(new DummyEventForConsuming('Sup.'));


### PR DESCRIPTION
This abstract class allows you to create handle methods that are payload specific. This prevents you from having to unwrap it in your consumer. For convenience the message instance itself is passed along as the second argument, in case you need the aggregate root ID or any other headers.

Example:

```php
<?php

use EventSauce\EventSourcing\EventConsumer;

class MyEventConsumer extends EventConsumer
{
    public function handleSomeEvent(SomeEvent $event)
    {
        // handle the event.
    }
}
```