### PR TITLE
Feature: require history for reconstitution.

### DIFF
--- a/docs/docs/getting-started/1-creating-an-aggregate-root.md
+++ b/docs/docs/getting-started/1-creating-an-aggregate-root.md
@@ -26,6 +26,10 @@ class AcmeProcess implements AggregateRoot
 }
 ```
 
+> NOTE: The default reconstitution mechanism allows aggregates to be
+> constructed without history. Use the `AggregateRootBehaviourWithRequiredHistory` trait instead.
+
+
 ### Aggregate Construction
 
 The `AggregateRootBehavior` trait includes a constructor, accepting an Aggregate

--- a/src/AggregateRootBehaviourWithRequiredHistory.php
+++ b/src/AggregateRootBehaviourWithRequiredHistory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\EventSourcing;
+
+use Generator;
+
+trait AggregateRootBehaviourWithRequiredHistory
+{
+    use AggregateRootBehaviour {
+        AggregateRootBehaviour::reconstituteFromEvents as defaultAggregateRootReconstitute;
+    }
+
+    public static function reconstituteFromEvents(AggregateRootId $aggregateRootId, Generator $events): AggregateRoot
+    {
+        $aggregateRoot = static::defaultAggregateRootReconstitute($aggregateRootId, $events);
+
+        if ($aggregateRoot->aggregateRootVersion() === 0) {
+            throw new InvalidAggregateRootReconstitutionException();
+        }
+
+        return $aggregateRoot;
+    }
+}

--- a/src/AggregateRootBehaviourWithRequiredHistory.php
+++ b/src/AggregateRootBehaviourWithRequiredHistory.php
@@ -9,7 +9,7 @@ use Generator;
 trait AggregateRootBehaviourWithRequiredHistory
 {
     use AggregateRootBehaviour {
-        AggregateRootBehaviour::reconstituteFromEvents as defaultAggregateRootReconstitute;
+        AggregateRootBehaviour::reconstituteFromEvents as private defaultAggregateRootReconstitute;
     }
 
     public static function reconstituteFromEvents(AggregateRootId $aggregateRootId, Generator $events): AggregateRoot

--- a/src/AggregateRootBehaviourWithRequiredHistory.php
+++ b/src/AggregateRootBehaviourWithRequiredHistory.php
@@ -16,7 +16,7 @@ trait AggregateRootBehaviourWithRequiredHistory
     {
         $aggregateRoot = static::defaultAggregateRootReconstitute($aggregateRootId, $events);
 
-        if ($aggregateRoot->aggregateRootVersion() === 0) {
+        if (0 === $aggregateRoot->aggregateRootVersion()) {
             throw new InvalidAggregateRootReconstitutionException();
         }
 

--- a/src/Integration/DummyAggregateRootId.php
+++ b/src/Integration/DummyAggregateRootId.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace EventSauce\EventSourcing\Integration\TestingAggregates;
+namespace EventSauce\EventSourcing\Integration;
 
 use EventSauce\EventSourcing\AggregateRootId;
 use Ramsey\Uuid\Uuid;

--- a/src/Integration/DummyAggregateRootId.php
+++ b/src/Integration/DummyAggregateRootId.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-namespace EventSauce\EventSourcing\Integration\TestingAggregates;
 namespace EventSauce\EventSourcing\Integration;
 
 use EventSauce\EventSourcing\AggregateRootId;

--- a/src/Integration/RequiringHistoryWithAggregateRootConstruction/AggregateRootConstructionTest.php
+++ b/src/Integration/RequiringHistoryWithAggregateRootConstruction/AggregateRootConstructionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace EventSauce\EventSourcing\Integration\RequiringHistoryWithAggregateRootConstruction;
+
+use EventSauce\EventSourcing\AggregateRoot;
+use EventSauce\EventSourcing\ConstructingAggregateRootRepository;
+use EventSauce\EventSourcing\InMemoryMessageRepository;
+use EventSauce\EventSourcing\Integration\DummyAggregateRootId;
+use EventSauce\EventSourcing\InvalidAggregateRootReconstitutionException;
+use PHPUnit\Framework\TestCase;
+
+class AggregateRootConstructionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function expecting_an_exception_without_history()
+    {
+        $this->expectException(InvalidAggregateRootReconstitutionException::class);
+        $repository = new ConstructingAggregateRootRepository(
+            AggregateThatRequiredHistoryForReconstitutionStub::class,
+            new InMemoryMessageRepository()
+        );
+
+        $repository->retrieve(DummyAggregateRootId::fromString('nope'));
+    }
+
+    /**
+     * @test
+     */
+    public function expecting_an_aggregate_when_there_is_history()
+    {
+        $repository = new ConstructingAggregateRootRepository(
+            AggregateThatRequiredHistoryForReconstitutionStub::class,
+            new InMemoryMessageRepository()
+        );
+        $id = DummyAggregateRootId::fromString('nope');
+        $repository->persistEvents($id, 1, new DummyInternalEvent());
+        $aggregateRoot = $repository->retrieve($id);
+        $this->assertInstanceOf(AggregateThatRequiredHistoryForReconstitutionStub::class, $aggregateRoot);
+    }
+
+    /**
+     * @test
+     */
+    public function constructing_the_aggregate_using_a_named_constructor()
+    {
+        $id = DummyAggregateRootId::fromString('nope');
+        $aggregate = AggregateThatRequiredHistoryForReconstitutionStub::start($id);
+        $this->assertInstanceOf(AggregateRoot::class, $aggregate);
+    }
+}

--- a/src/Integration/RequiringHistoryWithAggregateRootConstruction/AggregateRootConstructionTest.php
+++ b/src/Integration/RequiringHistoryWithAggregateRootConstruction/AggregateRootConstructionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing\Integration\RequiringHistoryWithAggregateRootConstruction;
 
 use EventSauce\EventSourcing\AggregateRoot;
@@ -14,7 +16,7 @@ class AggregateRootConstructionTest extends TestCase
     /**
      * @test
      */
-    public function expecting_an_exception_without_history()
+    public function expecting_an_exception_without_history(): void
     {
         $this->expectException(InvalidAggregateRootReconstitutionException::class);
         $repository = new ConstructingAggregateRootRepository(
@@ -28,7 +30,7 @@ class AggregateRootConstructionTest extends TestCase
     /**
      * @test
      */
-    public function expecting_an_aggregate_when_there_is_history()
+    public function expecting_an_aggregate_when_there_is_history(): void
     {
         $repository = new ConstructingAggregateRootRepository(
             AggregateThatRequiredHistoryForReconstitutionStub::class,
@@ -43,7 +45,7 @@ class AggregateRootConstructionTest extends TestCase
     /**
      * @test
      */
-    public function constructing_the_aggregate_using_a_named_constructor()
+    public function constructing_the_aggregate_using_a_named_constructor(): void
     {
         $id = DummyAggregateRootId::fromString('nope');
         $aggregate = AggregateThatRequiredHistoryForReconstitutionStub::start($id);

--- a/src/Integration/RequiringHistoryWithAggregateRootConstruction/AggregateThatRequiredHistoryForReconstitutionStub.php
+++ b/src/Integration/RequiringHistoryWithAggregateRootConstruction/AggregateThatRequiredHistoryForReconstitutionStub.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace EventSauce\EventSourcing\Integration\RequiringHistoryWithAggregateRootConstruction;
+
+use EventSauce\EventSourcing\AggregateRoot;
+use EventSauce\EventSourcing\AggregateRootBehaviourWithRequiredHistory;
+use EventSauce\EventSourcing\Integration\DummyAggregateRootId;
+
+class AggregateThatRequiredHistoryForReconstitutionStub implements AggregateRoot
+{
+    use AggregateRootBehaviourWithRequiredHistory;
+
+    public static function start(DummyAggregateRootId $id)
+    {
+        $aggregate = new static($id);
+        $aggregate->recordThat(new DummyInternalEvent());
+
+        return $aggregate;
+    }
+
+    protected function applyDummyInternalEvent(DummyInternalEvent $event)
+    {
+        // can be ignored
+    }
+}

--- a/src/Integration/RequiringHistoryWithAggregateRootConstruction/AggregateThatRequiredHistoryForReconstitutionStub.php
+++ b/src/Integration/RequiringHistoryWithAggregateRootConstruction/AggregateThatRequiredHistoryForReconstitutionStub.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing\Integration\RequiringHistoryWithAggregateRootConstruction;
 
 use EventSauce\EventSourcing\AggregateRoot;
@@ -18,7 +20,7 @@ class AggregateThatRequiredHistoryForReconstitutionStub implements AggregateRoot
         return $aggregate;
     }
 
-    protected function applyDummyInternalEvent(DummyInternalEvent $event)
+    protected function applyDummyInternalEvent(DummyInternalEvent $event): void
     {
         // can be ignored
     }

--- a/src/Integration/RequiringHistoryWithAggregateRootConstruction/DummyInternalEvent.php
+++ b/src/Integration/RequiringHistoryWithAggregateRootConstruction/DummyInternalEvent.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing\Integration\RequiringHistoryWithAggregateRootConstruction;
 
 class DummyInternalEvent
 {
-
 }

--- a/src/Integration/RequiringHistoryWithAggregateRootConstruction/DummyInternalEvent.php
+++ b/src/Integration/RequiringHistoryWithAggregateRootConstruction/DummyInternalEvent.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace EventSauce\EventSourcing\Integration\RequiringHistoryWithAggregateRootConstruction;
+
+class DummyInternalEvent
+{
+
+}

--- a/src/Integration/TestingAggregates/DummyAggregate.php
+++ b/src/Integration/TestingAggregates/DummyAggregate.php
@@ -6,6 +6,7 @@ namespace EventSauce\EventSourcing\Integration\TestingAggregates;
 
 use EventSauce\EventSourcing\AggregateRoot;
 use EventSauce\EventSourcing\AggregateRootBehaviour;
+use EventSauce\EventSourcing\Integration\DummyAggregateRootId;
 
 class DummyAggregate implements AggregateRoot
 {

--- a/src/Integration/TestingAggregates/ExampleAggregateRootTest.php
+++ b/src/Integration/TestingAggregates/ExampleAggregateRootTest.php
@@ -8,6 +8,7 @@ use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\AggregateRootRepository;
 use EventSauce\EventSourcing\AggregateRootTestCase;
 use EventSauce\EventSourcing\Header;
+use EventSauce\EventSourcing\Integration\DummyAggregateRootId;
 use EventSauce\EventSourcing\Message;
 use EventSauce\EventSourcing\PointInTime;
 use EventSauce\EventSourcing\Time\Clock;

--- a/src/Integration/TestingAggregates/InitiatorCommand.php
+++ b/src/Integration/TestingAggregates/InitiatorCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EventSauce\EventSourcing\Integration\TestingAggregates;
 
+use EventSauce\EventSourcing\Integration\DummyAggregateRootId;
+
 class InitiatorCommand
 {
     /**

--- a/src/InvalidAggregateRootReconstitutionException.php
+++ b/src/InvalidAggregateRootReconstitutionException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace EventSauce\EventSourcing;
+
+use RuntimeException;
+use Throwable;
+
+class InvalidAggregateRootReconstitutionException extends RuntimeException
+{
+}

--- a/src/InvalidAggregateRootReconstitutionException.php
+++ b/src/InvalidAggregateRootReconstitutionException.php
@@ -1,9 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing;
 
 use RuntimeException;
-use Throwable;
 
 class InvalidAggregateRootReconstitutionException extends RuntimeException
 {


### PR DESCRIPTION
This PR introduces a new aggregate root behaviour trait that forces the existence of history for an aggregate to prevent them from being instantiated without events.

/cc @asgrim Might be something for you.