### PR TITLE
Reverse order of tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ install:
     - travis_retry composer install
 
 script:
-    - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
-    - if [[ "${TRAVIS_PHP_VERSION}" == "7.3" ]]; then vendor/bin/phpstan analyze --level max -c phpstan.neon src; fi
     - if [[ "${TRAVIS_PHP_VERSION}" == "7.3" ]]; then vendor/bin/php-cs-fixer fix -v --dry-run --stop-on-violation --using-cache=no; fi
+    - if [[ "${TRAVIS_PHP_VERSION}" == "7.3" ]]; then vendor/bin/phpstan analyze --level max -c phpstan.neon src; fi
+    - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
     - wget https://scrutinizer-ci.com/ocular.phar


### PR DESCRIPTION
This is just a suggestion but reversing the tests to let faster running ones run first will allow for a shorter feedback loop when submitting prs. Code analysers often run much faster than the actual test suite.