### PR TITLE
Add time of recording accessor to Message

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -56,6 +56,11 @@ final class Message
         return $this->headers[Header::AGGREGATE_ROOT_ID] ?? null;
     }
 
+    public function timeOfRecording(): PointInTime
+    {
+        return PointInTime::fromString($this->headers[Header::TIME_OF_RECORDING]);
+    }
+
     public function header(string $key)
     {
         return $this->headers[$key] ?? null;

--- a/src/MessageTest.php
+++ b/src/MessageTest.php
@@ -51,7 +51,6 @@ class MessageTest extends TestCase
         $event = PayloadStub::create('some value');
         $message = new Message($event);
         $timeOfRecording = (new TestClock())->pointInTime();
-        $this->assertNull($message->aggregateRootId());
         $message = $message->withHeader(Header::TIME_OF_RECORDING, $timeOfRecording->toString());
         $this->assertInstanceOf(PointInTime::class, $message->timeOfRecording());
         $this->assertSame($timeOfRecording->toString(), $message->timeOfRecording()->toString());

--- a/src/MessageTest.php
+++ b/src/MessageTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EventSauce\EventSourcing;
 
+use EventSauce\EventSourcing\Time\TestClock;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -40,5 +41,19 @@ class MessageTest extends TestCase
         $this->assertNull($message->aggregateRootId());
         $message = $message->withHeader(Header::AGGREGATE_ROOT_ID, UuidAggregateRootId::create());
         $this->assertInstanceOf(AggregateRootId::class, $message->aggregateRootId());
+    }
+
+    /**
+     * @test
+     */
+    public function time_of_recording_accessor(): void
+    {
+        $event = PayloadStub::create('some value');
+        $message = new Message($event);
+        $timeOfRecording = (new TestClock())->pointInTime();
+        $this->assertNull($message->aggregateRootId());
+        $message = $message->withHeader(Header::TIME_OF_RECORDING, $timeOfRecording->toString());
+        $this->assertInstanceOf(PointInTime::class, $message->timeOfRecording());
+        $this->assertSame($timeOfRecording->toString(), $message->timeOfRecording()->toString());
     }
 }


### PR DESCRIPTION
It makes a lot of sense to simplify the process of retrieving the time of recording, imo.

What do you think of this implementation?