### PR TITLE
fix: Avoid persisting when events are empty

### DIFF
--- a/src/ConstructingAggregateRootRepository.php
+++ b/src/ConstructingAggregateRootRepository.php
@@ -76,6 +76,10 @@ final class ConstructingAggregateRootRepository implements AggregateRootReposito
 
     public function persistEvents(AggregateRootId $aggregateRootId, int $aggregateRootVersion, object ...$events): void
     {
+        if (count($events) === 0) {
+            return;
+        }
+
         // decrease the aggregate root version by the number of raised events
         // so the version of each message represents the version at the time
         // of recording.


### PR DESCRIPTION
When trying to persist an aggregate root with no pending events, it still triggers the persistence and dispatching flow.

Returning early fixes that problem.

An example of this is when you throw an exception, when a command is handled.