### PR TITLE
Ignoring tests folders on package distribution.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,7 +12,6 @@ phpunit.xml.dist export-ignore
 README.md export-ignore
 /src/Integration/ export-ignore
 /src/CodeGeneration/Fixtures/ export-ignore
-/src/CodeGeneration/Fixtures/ export-ignore
 **/*Test.php export-ignore
 **/*Stub.php export-ignore
 **/*Tests export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,8 @@ phpunit.xml.dist export-ignore
 README.md export-ignore
 /src/Integration/ export-ignore
 /src/CodeGeneration/Fixtures/ export-ignore
+/src/CodeGeneration/Fixtures/ export-ignore
 **/*Test.php export-ignore
 **/*Stub.php export-ignore
+**/*Tests export-ignore
 /docs export-ignore


### PR DESCRIPTION
Test files under `\EventSauce\EventSourcing\Snapshotting\Tests\` were being distributed with the package.

By executing `git check-attr export-ignore -- src/Snapshotting/Tests/` I get a `src/Snapshotting/Tests/: export-ignore: set`, so I think it's working.

See: https://git-scm.com/docs/git-check-attr 
