### PR TITLE
PHP 8 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage/
 coverage.xml
 composer.lock
 .idea/
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: xenial
 
 php:
     - 7.2
@@ -14,8 +15,6 @@ matrix:
 cache:
     directories:
         - vendor
-
-sudo: false
 
 install:
     - travis_retry composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ language: php
 php:
     - 7.2
     - 7.3
-    - 7.4snapshot
+    - 7.4
     - nightly
 
 matrix:
     allow_failures:
-        -   php: 7.4snapshot
+        -   php: 7.4
         -   php: nightly
 
 cache:

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^0.11.16|^0.12.52",
-        "phpunit/phpunit": "^7.0|^8.0|^9.3",
-        "friendsofphp/php-cs-fixer": "^2.15"
+        "phpunit/phpunit": "^7.0|^8.0|^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "ramsey/uuid": "^3|^4",
         "symfony/yaml": "^3.2|^4.0|^5.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.11.16",
-        "phpunit/phpunit": "^7.0|^8.0",
+        "phpunit/phpunit": "^7.0|^8.0|^9.3",
         "friendsofphp/php-cs-fixer": "^2.15"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/yaml": "^3.2|^4.0|^5.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.11.16",
+        "phpstan/phpstan": "^0.11.16|^0.12.52",
         "phpunit/phpunit": "^7.0|^8.0|^9.3",
         "friendsofphp/php-cs-fixer": "^2.15"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^0.11.16|^0.12.52",
-        "phpunit/phpunit": "^7.0|^8.0|^9.3"
+        "phpunit/phpunit": "^7.0|^8.0|^9.3",
+        "friendsofphp/php-cs-fixer": "^2.15"
     },
     "autoload": {
         "psr-4": {

--- a/src/Snapshotting/Tests/LightSwitch.php
+++ b/src/Snapshotting/Tests/LightSwitch.php
@@ -48,7 +48,7 @@ class LightSwitch implements AggregateRootWithSnapshotting
         $this->state = $event->state();
     }
 
-    protected static function reconstituteFromSnapshotState(AggregateRootId $id, bool $state): AggregateRootWithSnapshotting
+    protected static function reconstituteFromSnapshotState(AggregateRootId $id, $state): AggregateRootWithSnapshotting
     {
         $lightSwitch = new static($id);
         $lightSwitch->state = $state;


### PR DESCRIPTION
This PR should provide compatibility with PHP 8. When I run the tests locally on PHP 8 in Docker they pass. 

Note that php-cs-fixer isn't patched yet so builds will fail atm (I removed the dependency locally to test). But at least this way EventSauce can already be installed on PHP 8.

Would appreciate a merge and tag so I can patch https://github.com/EventSaucePHP/LaravelEventSauce for PHP 8 :)