### PR TITLE
Add a delimiter in the timezone to allow MySQL insert the value into the database

### DIFF
--- a/src/PointInTime.php
+++ b/src/PointInTime.php
@@ -11,7 +11,7 @@ final class PointInTime
     /**
      * @private
      */
-    const DATE_TIME_FORMAT = 'Y-m-d H:i:s.uO';
+    const DATE_TIME_FORMAT = 'Y-m-d H:i:s.uP';
 
     /**
      * @var DateTimeImmutable

--- a/src/PointInTimeTest.php
+++ b/src/PointInTimeTest.php
@@ -15,9 +15,9 @@ class PointInTimeTest extends TestCase
      */
     public function creating_from_string(): void
     {
-        $pointInTime = PointInTime::fromString('2017-01-01 10:30:00.000000+0000');
-        $this->assertEquals('2017-01-01 10:30:00.000000+0000', $pointInTime->toString());
-        $this->assertEquals('2017-01-01 10:30:00.000000+0000', (string) $pointInTime);
+        $pointInTime = PointInTime::fromString('2017-01-01 10:30:00.000000+00:00');
+        $this->assertEquals('2017-01-01 10:30:00.000000+00:00', $pointInTime->toString());
+        $this->assertEquals('2017-01-01 10:30:00.000000+00:00', (string) $pointInTime);
     }
 
     /**
@@ -34,7 +34,7 @@ class PointInTimeTest extends TestCase
      */
     public function creating_from_date_time(): void
     {
-        $dateTime = DateTimeImmutable::createFromFormat('Y-m-d H:i:s.uO', '2017-01-01 10:30:00.000000+0000');
+        $dateTime = DateTimeImmutable::createFromFormat('Y-m-d H:i:s.uO', '2017-01-01 10:30:00.000000+00:00');
         $this->assertNotFalse($dateTime);
         $pointInTime = PointInTime::fromDateTime($dateTime);
         $this->assertEquals($dateTime, $pointInTime->dateTime());


### PR DESCRIPTION
Hi @frankdejonge ,

This pull request is to change the format of `PointInTime::DATE_TIME_FORMAT`. The reason is that MySQL (8.0.22) does not accept timezones without delimiters.

The following MySQL (8.0.22) error occurs with a `DATETIME` column in the events table.
```
SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime value: '2020-11-09 10:52:03.707881+0000' for column 'time_of_recording' at row 1"
```

The database table has the following reference:
```
CREATE TABLE IF NOT EXISTS domain_messages (
    event_id VARCHAR(36) NOT NULL,
    event_type VARCHAR(100) NOT NULL,
    aggregate_root_id VARCHAR(36) NOT NULL,
    aggregate_root_version MEDIUMINT(36) UNSIGNED NOT NULL,
    time_of_recording DATETIME(6) NOT NULL,
    payload JSON NOT NULL,
    INDEX aggregate_root_id (aggregate_root_id),
    UNIQUE KEY unique_id_and_version (aggregate_root_id, aggregate_root_version ASC)
) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci ENGINE = InnoDB
```

With this change the `DATETIME` value (`2020-11-09 10:52:03.707881+00:00`; with delimiter in the timezone) can be saved in the database.