### PR TITLE
Allow consumers to more easily start working with eventsauce/eventsauce:^1@dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,10 @@
         "psr-4": {
             "EventSauce\\EventSourcing\\": "src/"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-version/1.0.0": "1.x-dev"
+        }
     }
 }


### PR DESCRIPTION
I'm like 99.9% sure this works this way. :) I was able to run the following command and it let me require the branch just fine. Assuming Composer rules for `branch-alias` are identical to `require`, I think this should be good to go.

```
composer require eventsauce/eventsauce:dev-version/1.0.0
```

End result after this is merged is that Packagist (and thus Composer) should allow someone to instead target 1.x:

```
composer require eventsauce/eventsauce:^1@dev
```
