### PR TITLE
Allow consumers to more easily start working with eventsauce/eventsauce:^1@dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,10 @@
         "psr-4": {
             "EventSauce\\EventSourcing\\": "src/"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-version/1.0.0": "1.x-dev"
+        }
     }
 }


### PR DESCRIPTION
Apparently this needs to be done in the actual branch in order for it to work. This is a quick fix to get `eventsauce/eventsauce:^1@dev` working sooner rather than later. The long-term fix is in the email I sent this weekend. :)