### PR TITLE
Generics in repositories

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
 #          vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyze --level max -c phpstan.neon src
+        run: vendor/bin/phpstan analyze -c phpstan.neon
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose --coverage-text --coverage-clover=coverage.clover

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,9 @@
 parameters:
-	excludes_analyse:
-		- %rootDir%/../../../src/CodeGeneration/Fixtures/*
-		- %rootDir%/../../../src/Integration/*
-		- *Test.php
-	checkMissingIterableValueType: false
+    level: max
+    paths:
+        - src
+    excludes_analyse:
+        - %rootDir%/../../../src/CodeGeneration/Fixtures/*
+        - %rootDir%/../../../src/Integration/*
+        - *Test.php
+    checkMissingIterableValueType: false

--- a/src/AggregateRootRepository.php
+++ b/src/AggregateRootRepository.php
@@ -4,11 +4,19 @@ declare(strict_types=1);
 
 namespace EventSauce\EventSourcing;
 
+/**
+ * @template T of AggregateRoot
+ */
 interface AggregateRootRepository
 {
+    /**
+     * @phpstan-return T
+     */
     public function retrieve(AggregateRootId $aggregateRootId): object;
 
     /**
+     * @phpstan-param T $aggregateRoot
+     *
      * @return void
      */
     public function persist(object $aggregateRoot);

--- a/src/AggregateRootTestCase.php
+++ b/src/AggregateRootTestCase.php
@@ -8,11 +8,10 @@ use EventSauce\EventSourcing\TestUtilities\ConsumerThatSerializesMessages;
 use EventSauce\EventSourcing\Time\Clock;
 use EventSauce\EventSourcing\Time\TestClock;
 use Exception;
-use LogicException;
-use PHPUnit\Framework\TestCase;
-
 use function get_class;
+use LogicException;
 use function method_exists;
+use PHPUnit\Framework\TestCase;
 use function sprintf;
 
 /**
@@ -150,7 +149,6 @@ abstract class AggregateRootTestCase extends TestCase
 
     /**
      * @param mixed[] $arguments
-     *
      * @return $this
      */
     protected function when(...$arguments)
@@ -211,8 +209,8 @@ abstract class AggregateRootTestCase extends TestCase
 
         if (
             null !== $caughtException && (
-                null === $expectedException ||
-                get_class($expectedException) !== get_class($caughtException))
+            null === $expectedException ||
+            get_class($expectedException) !== get_class($caughtException))
         ) {
             throw $caughtException;
         }

--- a/src/AggregateRootTestCase.php
+++ b/src/AggregateRootTestCase.php
@@ -8,10 +8,11 @@ use EventSauce\EventSourcing\TestUtilities\ConsumerThatSerializesMessages;
 use EventSauce\EventSourcing\Time\Clock;
 use EventSauce\EventSourcing\Time\TestClock;
 use Exception;
-use function get_class;
 use LogicException;
-use function method_exists;
 use PHPUnit\Framework\TestCase;
+
+use function get_class;
+use function method_exists;
 use function sprintf;
 
 /**
@@ -25,6 +26,8 @@ abstract class AggregateRootTestCase extends TestCase
     protected $messageRepository;
 
     /**
+     * @phpstan-var AggregateRootRepository<AggregateRoot>
+     *
      * @var AggregateRootRepository
      */
     protected $repository;
@@ -121,6 +124,9 @@ abstract class AggregateRootTestCase extends TestCase
 
     abstract protected function newAggregateRootId(): AggregateRootId;
 
+    /**
+     * @phpstan-return class-string<AggregateRoot>
+     */
     abstract protected function aggregateRootClassName(): string;
 
     /**
@@ -144,12 +150,13 @@ abstract class AggregateRootTestCase extends TestCase
 
     /**
      * @param mixed[] $arguments
+     *
      * @return $this
      */
     protected function when(...$arguments)
     {
         try {
-            if ( ! method_exists($this, 'handle')) {
+            if (!method_exists($this, 'handle')) {
                 throw new LogicException(sprintf('Class %s is missing a ::handle method.', get_class($this)));
             }
 
@@ -204,8 +211,8 @@ abstract class AggregateRootTestCase extends TestCase
 
         if (
             null !== $caughtException && (
-            null === $expectedException ||
-            get_class($expectedException) !== get_class($caughtException))
+                null === $expectedException ||
+                get_class($expectedException) !== get_class($caughtException))
         ) {
             throw $caughtException;
         }
@@ -244,6 +251,13 @@ abstract class AggregateRootTestCase extends TestCase
         return new MessageDecoratorChain(new DefaultHeadersDecorator());
     }
 
+    /**
+     * @template T of AggregateRoot
+     *
+     * @phpstan-param class-string<T> $className
+     *
+     * @phpstan-return AggregateRootRepository<T>
+     */
     protected function aggregateRootRepository(
         string $className,
         MessageRepository $repository,

--- a/src/AggregateRootTestCase.php
+++ b/src/AggregateRootTestCase.php
@@ -154,7 +154,7 @@ abstract class AggregateRootTestCase extends TestCase
     protected function when(...$arguments)
     {
         try {
-            if (!method_exists($this, 'handle')) {
+            if ( ! method_exists($this, 'handle')) {
                 throw new LogicException(sprintf('Class %s is missing a ::handle method.', get_class($this)));
             }
 

--- a/src/ConstructingAggregateRootRepository.php
+++ b/src/ConstructingAggregateRootRepository.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace EventSauce\EventSourcing;
 
-use Generator;
-
 use function assert;
 use function count;
+use Generator;
 
 /**
  * @template T of AggregateRoot

--- a/src/ConstructingAggregateRootRepository.php
+++ b/src/ConstructingAggregateRootRepository.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 
 namespace EventSauce\EventSourcing;
 
-use function assert;
-use function count;
 use Generator;
 
+use function assert;
+use function count;
+
+/**
+ * @template T of AggregateRoot
+ *
+ * @template-implements AggregateRootRepository<T>
+ */
 final class ConstructingAggregateRootRepository implements AggregateRootRepository
 {
     /**
@@ -30,6 +36,9 @@ final class ConstructingAggregateRootRepository implements AggregateRootReposito
      */
     private $dispatcher;
 
+    /**
+     * @param class-string<T> $aggregateRootClassName
+     */
     public function __construct(
         string $aggregateRootClassName,
         MessageRepository $messageRepository,
@@ -45,6 +54,7 @@ final class ConstructingAggregateRootRepository implements AggregateRootReposito
     public function retrieve(AggregateRootId $aggregateRootId): object
     {
         /** @var AggregateRoot $className */
+        /** @phpstan-var class-string<T> $className */
         $className = $this->aggregateRootClassName;
         $events = $this->retrieveAllEvents($aggregateRootId);
 

--- a/src/EventStager.php
+++ b/src/EventStager.php
@@ -13,6 +13,7 @@ class EventStager
 
     /**
      * @phpstan-var AggregateRootRepository<AggregateRoot>
+     *
      * @var AggregateRootRepository
      */
     private $repository;

--- a/src/EventStager.php
+++ b/src/EventStager.php
@@ -12,6 +12,7 @@ class EventStager
     private $id;
 
     /**
+     * @phpstan-var AggregateRootRepository<AggregateRoot>
      * @var AggregateRootRepository
      */
     private $repository;
@@ -26,8 +27,15 @@ class EventStager
      */
     private $messageRepository;
 
-    public function __construct(AggregateRootId $id, InMemoryMessageRepository $messageRepository, AggregateRootRepository $repository, AggregateRootTestCase $testCase)
-    {
+    /**
+     * @phpstan-param AggregateRootRepository<AggregateRoot> $repository
+     */
+    public function __construct(
+        AggregateRootId $id,
+        InMemoryMessageRepository $messageRepository,
+        AggregateRootRepository $repository,
+        AggregateRootTestCase $testCase
+    ) {
         $this->id = $id;
         $this->repository = $repository;
         $this->testCase = $testCase;

--- a/src/Snapshotting/AggregateRootRepositoryWithSnapshotting.php
+++ b/src/Snapshotting/AggregateRootRepositoryWithSnapshotting.php
@@ -7,9 +7,20 @@ namespace EventSauce\EventSourcing\Snapshotting;
 use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\AggregateRootRepository;
 
+/**
+ * @template T of AggregateRootWithSnapshotting
+ *
+ * @template-extends AggregateRootRepository<T>
+ */
 interface AggregateRootRepositoryWithSnapshotting extends AggregateRootRepository
 {
+    /**
+     * @phpstan-return AggregateRootWithSnapshotting
+     */
     public function retrieveFromSnapshot(AggregateRootId $aggregateRootId): object;
 
+    /**
+     * @phpstan-param T $aggregateRoot
+     */
     public function storeSnapshot(AggregateRootWithSnapshotting $aggregateRoot): void;
 }

--- a/src/Snapshotting/ConstructingAggregateRootRepositoryWithSnapshotting.php
+++ b/src/Snapshotting/ConstructingAggregateRootRepositoryWithSnapshotting.php
@@ -33,7 +33,9 @@ final class ConstructingAggregateRootRepositoryWithSnapshotting implements Aggre
     private $snapshotRepository;
 
     /**
-     * @var AggregateRootRepository<T>
+     * @phpstan-var AggregateRootRepository<T>
+     *
+     * @var AggregateRootRepository
      */
     private $regularRepository;
 

--- a/src/Snapshotting/ConstructingAggregateRootRepositoryWithSnapshotting.php
+++ b/src/Snapshotting/ConstructingAggregateRootRepositoryWithSnapshotting.php
@@ -10,6 +10,11 @@ use EventSauce\EventSourcing\Message;
 use EventSauce\EventSourcing\MessageRepository;
 use Generator;
 
+/**
+ * @template T of AggregateRootWithSnapshotting
+ *
+ * @template-implements AggregateRootRepositoryWithSnapshotting<T>
+ */
 final class ConstructingAggregateRootRepositoryWithSnapshotting implements AggregateRootRepositoryWithSnapshotting
 {
     /**
@@ -28,10 +33,14 @@ final class ConstructingAggregateRootRepositoryWithSnapshotting implements Aggre
     private $snapshotRepository;
 
     /**
-     * @var AggregateRootRepository
+     * @var AggregateRootRepository<T>
      */
     private $regularRepository;
 
+    /**
+     * @phpstan-param class-string<T> $regularRepository
+     * @phpstan-param AggregateRootRepository<T> $regularRepository
+     */
     public function __construct(
         string $aggregateRootClassName,
         MessageRepository $messageRepository,
@@ -48,10 +57,11 @@ final class ConstructingAggregateRootRepositoryWithSnapshotting implements Aggre
     {
         $snapshot = $this->snapshotRepository->retrieve($aggregateRootId);
 
-        if ( ! $snapshot instanceof Snapshot) {
+        if (!$snapshot instanceof Snapshot) {
             return $this->retrieve($aggregateRootId);
         }
 
+        /** @phpstan-var T $className */
         /** @var AggregateRootWithSnapshotting $className */
         $className = $this->aggregateRootClassName;
         $events = $this->retrieveAllEventsAfterVersion($aggregateRootId, $snapshot->aggregateRootVersion());


### PR DESCRIPTION
This adds generics that can be used to let phpstan and psalm resolve types of returned objects from repositories.

You can now hint repositories like this:
```php
/**
 * @param AggregateRootRepository<SomeAggregateRoot> $repository
 */
public function something(AggregateRootRepository $repository): void {}
```