### PR TITLE
Fix nullable return types on methods

### DIFF
--- a/src/CodeGeneration/CodeDumper.php
+++ b/src/CodeGeneration/CodeDumper.php
@@ -138,8 +138,17 @@ EOF;
     {
         $methods = [];
         foreach ($this->fieldsFromDefinition($command) as $field) {
+            $resolvedType = $this->definitionGroup->resolveTypeAlias($field['type']);
+            $isNullable = (bool) ($field['nullable']
+                ?? $this->definitionGroup->isTypeNullable($field['type'])
+                ?? $this->definitionGroup->isTypeNullable($resolvedType));
+
+            if ($isNullable) {
+                $resolvedType = '?' . $resolvedType;
+            }
+
             $methods[] = <<<EOF
-    public function {$field['name']}(): {$this->definitionGroup->resolveTypeAlias($field['type'])}
+    public function {$field['name']}(): {$resolvedType}
     {
         return \$this->{$field['name']};
     }

--- a/src/CodeGeneration/Fixtures/definedWithYamlFixture.php
+++ b/src/CodeGeneration/Fixtures/definedWithYamlFixture.php
@@ -26,12 +26,12 @@ final class WeWentYamling implements SerializablePayload
         return $this->slogan;
     }
 
-    public function title(): string
+    public function title(): ?string
     {
         return $this->title;
     }
 
-    public function description(): string
+    public function description(): ?string
     {
         return $this->description;
     }


### PR DESCRIPTION
Methods generated for nullable fields are currently not nullable.
Implementation copied from https://github.com/EventSaucePHP/EventSauce/blob/version/1.0.0/src/CodeGeneration/CodeDumper.php#L115-L123