### PR TITLE
Update proper serializer type mention

### DIFF
--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -110,7 +110,7 @@ specific information.
 The message serializer is responsible for converting messages from and to a serialized form. When
 using (or implementing) a message repository, you'll want to use this rely on this interface.
 
-The core ships with a default (JSON based) serializer. You're free to implement your own
+The core ships with a default (array based) serializer. You're free to implement your own
 serialization strategy if your use-case requires it.
 
 Message serializers can be composed using decoration to provide more complex features such as upcasting.


### PR DESCRIPTION
It seems there's no JSON based serializer in EventSauce. Only an array based one: https://github.com/EventSaucePHP/EventSauce/blob/main/src/Serialization/ConstructingMessageSerializer.php#L26

See https://github.com/EventSaucePHP/EventSauce/issues/125