### PR TITLE
Fix: EventSourcedAggregateRootRepository correctly generates version-header

### DIFF
--- a/src/EventSourcedAggregateRootRepository.php
+++ b/src/EventSourcedAggregateRootRepository.php
@@ -85,10 +85,12 @@ class EventSourcedAggregateRootRepository implements AggregateRootRepository
         // of recording.
         $aggregateRootVersion = $aggregateRootVersion - count($events);
         $metadata = [Header::AGGREGATE_ROOT_ID => $aggregateRootId];
-        $messages = array_map(fn (object $event) => $this->decorator->decorate(new Message(
-            $event,
-            $metadata + [Header::AGGREGATE_ROOT_VERSION => ++$aggregateRootVersion]
-        )), $events);
+        $messages = array_map(function (object $event) use ($metadata, &$aggregateRootVersion) {
+            return $this->decorator->decorate(new Message(
+                $event,
+                $metadata + [Header::AGGREGATE_ROOT_VERSION => ++$aggregateRootVersion]
+            ));
+        }, $events);
 
         $this->messages->persist(...$messages);
         $this->dispatcher->dispatch(...$messages);


### PR DESCRIPTION
This code does not work as intended:

```php
$aggregateRootVersion = $aggregateRootVersion - count($events);
$metadata = [Header::AGGREGATE_ROOT_ID => $aggregateRootId];
$messages = array_map(fn (object $event) => $this->decorator->decorate(new Message(
    $event,
    $metadata + [Header::AGGREGATE_ROOT_VERSION => ++$aggregateRootVersion]
)), $events);
```

The problem here is, that short arrow function access the variables outside their scope in a by-value style. That's why each Message ends up with the same version, when calling the function once.