### PR TITLE
Support static return types across the board

### DIFF
--- a/src/AggregateRootId.php
+++ b/src/AggregateRootId.php
@@ -8,5 +8,5 @@ interface AggregateRootId
 {
     public function toString(): string;
 
-    public static function fromString(string $aggregateRootId): self;
+    public static function fromString(string $aggregateRootId): static;
 }

--- a/src/CodeGeneration/CodeDumper.php
+++ b/src/CodeGeneration/CodeDumper.php
@@ -180,7 +180,7 @@ EOF;
         }
 
         return <<<EOF
-    public static function fromPayload(array \$payload): self
+    public static function fromPayload(array \$payload): static
     {
         return new $name($arguments);
     }

--- a/src/CodeGeneration/Fixtures/commandsWithInterfaces.php
+++ b/src/CodeGeneration/Fixtures/commandsWithInterfaces.php
@@ -8,7 +8,7 @@ use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
 final class EventWithInterfaceMarker implements \EventSauce\EventSourcing\CodeGeneration\Fixtures\MarkerInterfaceStub, SerializablePayload
 {
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new EventWithInterfaceMarker();
     }
@@ -21,7 +21,7 @@ final class EventWithInterfaceMarker implements \EventSauce\EventSourcing\CodeGe
 
 final class CommandWithInterfaceMarker implements \EventSauce\EventSourcing\CodeGeneration\Fixtures\MarkerInterfaceStub, SerializablePayload
 {
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new CommandWithInterfaceMarker();
     }
@@ -34,7 +34,7 @@ final class CommandWithInterfaceMarker implements \EventSauce\EventSourcing\Code
 
 final class AlsoCommandWithInterfaceMarker implements \EventSauce\EventSourcing\CodeGeneration\Fixtures\MarkerInterfaceStub, SerializablePayload
 {
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new AlsoCommandWithInterfaceMarker();
     }

--- a/src/CodeGeneration/Fixtures/definedWithYamlFixture.php
+++ b/src/CodeGeneration/Fixtures/definedWithYamlFixture.php
@@ -36,7 +36,7 @@ final class WeWentYamling implements SerializablePayload
         return $this->description;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new WeWentYamling(
             \Ramsey\Uuid\Uuid::fromString($payload['reference']),
@@ -104,7 +104,7 @@ final class HideFinancialDetailsOfFraudulentCompany implements SerializablePaylo
         return $this->companyId;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new HideFinancialDetailsOfFraudulentCompany(
             \Ramsey\Uuid\Uuid::fromString($payload['companyId'])
@@ -147,7 +147,7 @@ final class GoYamling implements SerializablePayload
         return $this->slogan;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new GoYamling(
             \Ramsey\Uuid\Uuid::fromString($payload['reference']),

--- a/src/CodeGeneration/Fixtures/definedWithoutHelpersInYamlFixture.php
+++ b/src/CodeGeneration/Fixtures/definedWithoutHelpersInYamlFixture.php
@@ -24,7 +24,7 @@ final class UserSubscribedFromMailingList implements SerializablePayload
         return $this->mailingList;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new UserSubscribedFromMailingList(
             (string) $payload['username'],
@@ -59,7 +59,7 @@ final class SubscribeToMailingList implements SerializablePayload
         return $this->mailingList;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new SubscribeToMailingList(
             (string) $payload['username'],
@@ -100,7 +100,7 @@ final class UnsubscribeFromMailingList implements SerializablePayload
         return $this->reason;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new UnsubscribeFromMailingList(
             (string) $payload['username'],

--- a/src/CodeGeneration/Fixtures/definitionGroupWithCommandFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithCommandFixture.php
@@ -18,7 +18,7 @@ final class DoSomething implements SerializablePayload
         return $this->reason;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new DoSomething(
             (string) $payload['reason']

--- a/src/CodeGeneration/Fixtures/definitionGroupWithCommandTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithCommandTypePropertiesFixture.php
@@ -18,7 +18,7 @@ final class DoSomething implements SerializablePayload
         return $this->reason;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new DoSomething(
             (string) $payload['reason']

--- a/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsFixture.php
@@ -18,7 +18,7 @@ final class EventWithDescription implements SerializablePayload
         return $this->description;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new EventWithDescription(
             (string) $payload['description']

--- a/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsTypePropertiesFixture.php
@@ -18,7 +18,7 @@ final class EventWithDescription implements SerializablePayload
         return $this->description;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new EventWithDescription(
             (string) $payload['description']

--- a/src/CodeGeneration/Fixtures/definitionWithFieldsFromOtherDefinitionsFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionWithFieldsFromOtherDefinitionsFixture.php
@@ -18,7 +18,7 @@ final class BaseEvent implements SerializablePayload
         return $this->age;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new BaseEvent(
             (int) $payload['age']
@@ -45,7 +45,7 @@ final class ExtendedEvent implements SerializablePayload
         return $this->age;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new ExtendedEvent(
             (int) $payload['age']
@@ -72,7 +72,7 @@ final class BaseCommand implements SerializablePayload
         return $this->name;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new BaseCommand(
             (string) $payload['name']
@@ -99,7 +99,7 @@ final class ExtendedCommand implements SerializablePayload
         return $this->name;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new ExtendedCommand(
             (string) $payload['name']

--- a/src/CodeGeneration/Fixtures/groupWithEventWithNoFieldsFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithEventWithNoFieldsFixture.php
@@ -8,7 +8,7 @@ use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
 final class WithoutFields implements SerializablePayload
 {
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new WithoutFields();
     }

--- a/src/CodeGeneration/Fixtures/groupWithEventWithNoFieldsTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithEventWithNoFieldsTypePropertiesFixture.php
@@ -8,7 +8,7 @@ use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
 final class WithoutFields implements SerializablePayload
 {
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new WithoutFields();
     }

--- a/src/CodeGeneration/Fixtures/groupWithEventWithTwoRequiredFieldsFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithEventWithTwoRequiredFieldsFixture.php
@@ -24,7 +24,7 @@ final class ThisOne implements SerializablePayload
         return $this->description;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new ThisOne(
             (string) $payload['title'],

--- a/src/CodeGeneration/Fixtures/groupWithEventWithTwoRequiredFieldsTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithEventWithTwoRequiredFieldsTypePropertiesFixture.php
@@ -24,7 +24,7 @@ final class ThisOne implements SerializablePayload
         return $this->description;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new ThisOne(
             (string) $payload['title'],

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationFixture.php
@@ -18,7 +18,7 @@ final class WithFieldSerializers implements SerializablePayload
         return $this->items;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new WithFieldSerializers(
             array_map(function ($property) {

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventFixture.php
@@ -18,7 +18,7 @@ final class EventName implements SerializablePayload
         return $this->title;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new EventName(
             strtolower($payload['title'])

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventTypePropertiesFixture.php
@@ -18,7 +18,7 @@ final class EventName implements SerializablePayload
         return $this->title;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new EventName(
             strtolower($payload['title'])

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationTypePropertiesFixture.php
@@ -18,7 +18,7 @@ final class WithFieldSerializers implements SerializablePayload
         return $this->items;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new WithFieldSerializers(
             array_map(function ($property) {

--- a/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupFixture.php
+++ b/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupFixture.php
@@ -18,7 +18,7 @@ final class FirstEvent implements SerializablePayload
         return $this->firstField;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new FirstEvent(
             (string) $payload['firstField']
@@ -66,7 +66,7 @@ final class SecondEvent implements SerializablePayload
         return $this->secondField;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new SecondEvent(
             (string) $payload['secondField']

--- a/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupTypePropertiesFixture.php
@@ -18,7 +18,7 @@ final class FirstEvent implements SerializablePayload
         return $this->firstField;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new FirstEvent(
             (string) $payload['firstField']
@@ -66,7 +66,7 @@ final class SecondEvent implements SerializablePayload
         return $this->secondField;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new SecondEvent(
             (string) $payload['secondField']

--- a/src/CodeGeneration/Fixtures/simpleDefinitionGroupFixture.php
+++ b/src/CodeGeneration/Fixtures/simpleDefinitionGroupFixture.php
@@ -24,7 +24,7 @@ final class SomethingHappened implements SerializablePayload
         return $this->yolo;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new SomethingHappened(
             (string) $payload['what'],

--- a/src/CodeGeneration/Fixtures/simpleDefinitionGroupTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/simpleDefinitionGroupTypePropertiesFixture.php
@@ -24,7 +24,7 @@ final class SomethingHappened implements SerializablePayload
         return $this->yolo;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new SomethingHappened(
             (string) $payload['what'],

--- a/src/CodeGeneration/PayloadDefinition.php
+++ b/src/CodeGeneration/PayloadDefinition.php
@@ -27,14 +27,14 @@ final class PayloadDefinition
     /**
      * @return $this
      */
-    public function withFieldsFrom(string $otherType): self
+    public function withFieldsFrom(string $otherType): static
     {
         $this->fieldsFrom = $otherType;
 
         return $this;
     }
 
-    public function withInterface(string $interface): self
+    public function withInterface(string $interface): static
     {
         $this->interfaces[] = $interface;
 
@@ -56,7 +56,7 @@ final class PayloadDefinition
         return $this->fieldsFrom;
     }
 
-    public function field(string $name, string $type, string $example = null, ?bool $nullable = null): self
+    public function field(string $name, string $type, string $example = null, ?bool $nullable = null): static
     {
         $example = $example ?: $this->group->exampleForField($name);
         $this->fields[] = compact('name', 'type', 'example', 'nullable');
@@ -64,7 +64,7 @@ final class PayloadDefinition
         return $this;
     }
 
-    public function fieldSerializer(string $field, string $template): self
+    public function fieldSerializer(string $field, string $template): static
     {
         $this->fieldSerializers[$field] = $template;
 
@@ -76,7 +76,7 @@ final class PayloadDefinition
         return $this->fieldSerializers[$field] ?? $this->group->serializerForField($field);
     }
 
-    public function fieldDeserializer(string $field, string $template): self
+    public function fieldDeserializer(string $field, string $template): static
     {
         $this->fieldDeserializers[$field] = $template;
 

--- a/src/DummyAggregateRootId.php
+++ b/src/DummyAggregateRootId.php
@@ -26,10 +26,7 @@ final class DummyAggregateRootId implements AggregateRootId
         return new DummyAggregateRootId(bin2hex(random_bytes(25)));
     }
 
-    /**
-     * @return static
-     */
-    public static function fromString(string $aggregateRootId): AggregateRootId
+    public static function fromString(string $aggregateRootId): static
     {
         return new static($aggregateRootId);
     }

--- a/src/EventStub.php
+++ b/src/EventStub.php
@@ -33,13 +33,13 @@ final class EventStub implements SerializablePayload
         return $this->value;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
-        return new self($payload['value']);
+        return new static($payload['value']);
     }
 
-    public static function create(string $value = null): self
+    public static function create(string $value = null): static
     {
-        return self::fromPayload(compact('value'));
+        return static::fromPayload(compact('value'));
     }
 }

--- a/src/LibraryConsumptionTests/ComplexAggregates/DelegatedActionWasPerformed.php
+++ b/src/LibraryConsumptionTests/ComplexAggregates/DelegatedActionWasPerformed.php
@@ -17,7 +17,7 @@ class DelegatedActionWasPerformed implements SerializablePayload
         return ['counter' => $this->counter];
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new DelegatedActionWasPerformed($payload['counter']);
     }

--- a/src/LibraryConsumptionTests/ComplexAggregates/DelegatedAggregateWasChosen.php
+++ b/src/LibraryConsumptionTests/ComplexAggregates/DelegatedAggregateWasChosen.php
@@ -13,7 +13,7 @@ class DelegatedAggregateWasChosen implements SerializablePayload
         return [];
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new DelegatedAggregateWasChosen();
     }

--- a/src/LibraryConsumptionTests/ComplexAggregates/DelegatedAggregateWasDiscarded.php
+++ b/src/LibraryConsumptionTests/ComplexAggregates/DelegatedAggregateWasDiscarded.php
@@ -13,7 +13,7 @@ class DelegatedAggregateWasDiscarded implements SerializablePayload
         return [];
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new DelegatedAggregateWasDiscarded();
     }

--- a/src/LibraryConsumptionTests/RequiringHistoryWithAggregateRootConstruction/AggregateThatRequiredHistoryForReconstitutionStub.php
+++ b/src/LibraryConsumptionTests/RequiringHistoryWithAggregateRootConstruction/AggregateThatRequiredHistoryForReconstitutionStub.php
@@ -15,7 +15,7 @@ final class AggregateThatRequiredHistoryForReconstitutionStub implements Aggrega
 {
     use AggregateRootBehaviourWithRequiredHistory;
 
-    public static function start(DummyAggregateRootId $id): self
+    public static function start(DummyAggregateRootId $id): static
     {
         $aggregate = new static($id);
         $aggregate->recordThat(new DummyInternalEvent());

--- a/src/Serialization/SerializablePayload.php
+++ b/src/Serialization/SerializablePayload.php
@@ -8,5 +8,5 @@ interface SerializablePayload
 {
     public function toPayload(): array;
 
-    public static function fromPayload(array $payload): self;
+    public static function fromPayload(array $payload): static;
 }

--- a/src/Snapshotting/Tests/LightSwitchId.php
+++ b/src/Snapshotting/Tests/LightSwitchId.php
@@ -17,7 +17,7 @@ final class LightSwitchId implements AggregateRootId
         return $this->id;
     }
 
-    public static function fromString(string $aggregateRootId): AggregateRootId
+    public static function fromString(string $aggregateRootId): static
     {
         return new static($aggregateRootId);
     }

--- a/src/Snapshotting/Tests/LightSwitchWasFlipped.php
+++ b/src/Snapshotting/Tests/LightSwitchWasFlipped.php
@@ -26,14 +26,14 @@ final class LightSwitchWasFlipped implements SerializablePayload
         return $this->state;
     }
 
-    public static function on(): self
+    public static function on(): static
     {
         return new static(self::ON);
     }
 
-    public static function off(): self
+    public static function off(): static
     {
-        return new self(self::OFF);
+        return new static(self::OFF);
     }
 
     public function toPayload(): array
@@ -41,8 +41,8 @@ final class LightSwitchWasFlipped implements SerializablePayload
         return ['state' => $this->state];
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
-        return new self($payload['state']);
+        return new static($payload['state']);
     }
 }

--- a/src/TestUtilities/TestingAggregates/AggregateWasInitiated.php
+++ b/src/TestUtilities/TestingAggregates/AggregateWasInitiated.php
@@ -13,7 +13,7 @@ final class AggregateWasInitiated implements SerializablePayload
         return [];
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new static();
     }

--- a/src/TestUtilities/TestingAggregates/DummyIncrementingHappened.php
+++ b/src/TestUtilities/TestingAggregates/DummyIncrementingHappened.php
@@ -14,7 +14,7 @@ class DummyIncrementingHappened implements SerializablePayload
 {
     private int $number;
 
-    public function __construct(int $number)
+    final public function __construct(int $number)
     {
         $this->number = $number;
     }
@@ -24,9 +24,9 @@ class DummyIncrementingHappened implements SerializablePayload
         return ['number' => $this->number];
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
-        return new DummyIncrementingHappened($payload['number']);
+        return new static($payload['number']);
     }
 
     public function number(): int

--- a/src/TestUtilities/TestingAggregates/DummyTaskWasExecuted.php
+++ b/src/TestUtilities/TestingAggregates/DummyTaskWasExecuted.php
@@ -12,13 +12,17 @@ use EventSauce\EventSourcing\Serialization\SerializablePayload;
  */
 class DummyTaskWasExecuted implements SerializablePayload
 {
+    final public function __construct()
+    {
+    }
+
     public function toPayload(): array
     {
         return [];
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
-        return new self();
+        return new static();
     }
 }

--- a/src/UnableToDispatchMessages.php
+++ b/src/UnableToDispatchMessages.php
@@ -7,10 +7,10 @@ namespace EventSauce\EventSourcing;
 use RuntimeException;
 use Throwable;
 
-class UnableToDispatchMessages extends RuntimeException implements EventSauceException
+final class UnableToDispatchMessages extends RuntimeException implements EventSauceException
 {
-    public static function dueTo(string $reason, Throwable $previous = null): self
+    public static function dueTo(string $reason, Throwable $previous = null): static
     {
-        return new self("Unable to dispatch messages. {$reason}", 0, $previous);
+        return new static("Unable to dispatch messages. {$reason}", 0, $previous);
     }
 }

--- a/src/UnableToPersistMessages.php
+++ b/src/UnableToPersistMessages.php
@@ -9,8 +9,8 @@ use Throwable;
 
 final class UnableToPersistMessages extends RuntimeException implements EventSauceException
 {
-    public static function dueTo(string $reason, Throwable $previous = null): self
+    public static function dueTo(string $reason, Throwable $previous = null): static
     {
-        return new self("Unable to persist messages. {$reason}", 0, $previous);
+        return new static("Unable to persist messages. {$reason}", 0, $previous);
     }
 }

--- a/src/UnableToResolveTimeOfRecording.php
+++ b/src/UnableToResolveTimeOfRecording.php
@@ -8,8 +8,8 @@ use RuntimeException;
 
 final class UnableToResolveTimeOfRecording extends RuntimeException implements EventSauceException
 {
-    public static function fromFormatAndHeader(string $format, mixed $header): self
+    public static function fromFormatAndHeader(string $format, mixed $header): static
     {
-        return new self("Unable to determine time of recording from format \"{$format}\" and header \"{$header}\"");
+        return new static("Unable to determine time of recording from format \"{$format}\" and header \"{$header}\"");
     }
 }

--- a/src/UnableToRetrieveMessages.php
+++ b/src/UnableToRetrieveMessages.php
@@ -7,10 +7,10 @@ namespace EventSauce\EventSourcing;
 use RuntimeException;
 use Throwable;
 
-class UnableToRetrieveMessages extends RuntimeException implements EventSauceException
+final class UnableToRetrieveMessages extends RuntimeException implements EventSauceException
 {
-    public static function dueTo(string $reason, Throwable $previous = null): self
+    public static function dueTo(string $reason, Throwable $previous = null): static
     {
-        return new self("Unable to retrieve messages. {$reason}", 0, $previous);
+        return new static("Unable to retrieve messages. {$reason}", 0, $previous);
     }
 }

--- a/src/Upcasting/UpcastedPayloadStub.php
+++ b/src/Upcasting/UpcastedPayloadStub.php
@@ -9,7 +9,7 @@ use EventSauce\EventSourcing\Serialization\SerializablePayload;
 /**
  * @testAsset
  */
-class UpcastedPayloadStub implements SerializablePayload
+final class UpcastedPayloadStub implements SerializablePayload
 {
     private string $property;
 
@@ -23,8 +23,8 @@ class UpcastedPayloadStub implements SerializablePayload
         return ['property' => $this->property];
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
-        return new UpcastedPayloadStub($payload['property'] ?? 'undefined');
+        return new static($payload['property'] ?? 'undefined');
     }
 }


### PR DESCRIPTION
The `static` return type was introduced because people who use projects like EventSauce do a lot of work with static named constructors. By returning `static` instead of `self` (or the interface itself) it means people can typehint against the actual implementation in their own domain code without having to add additional typehints using phpdoc union types.

----

I imagine this would be a BC break but this is pretty important to me. Working with EventSauce 1.x for the first time I found myself struggling to convince my IDE that I wasn't doing something wrong or weird when had the interfaces and helper code it would have "Just Worked."

This PR may not be 100% right, yet, but it was easy to automate and tests pass and `phpstan` is reporting all green.

 * Changed all instances of `: self` to `: static` (to catch return type definitions)
 * Changed all instances of `new self` to `new static` (to catch implementations that instantiated a new instance of the type)
 * Changed a few cases by hand where the class was previous doing `new ActualClassName`
 * Made a few classes `final` and made a few constructors `final` to avoid this phpstan issue: https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static

----

Even with these changes, my IDE complains a bit. It suggests I revert it back to return a new instance of `DummyIncrementingHappened`:

![image](https://user-images.githubusercontent.com/191200/124195765-b9a9f080-da90-11eb-8d3d-96d77be7fa8c.png)

However, if I do that, phpstan starts to complain:

![image](https://user-images.githubusercontent.com/191200/124195885-e2ca8100-da90-11eb-820f-8135c7671665.png)

I opted for the non-Exceptions to have a final constructor:

![image](https://user-images.githubusercontent.com/191200/124196607-620c8480-da92-11eb-8e28-096b382eca4e.png)

And, for completeness, this is what phpstan says if these classes are not `final` and do not have a `final` constructor:

![image](https://user-images.githubusercontent.com/191200/124196007-1dccb480-da91-11eb-8556-0ab8163a06dc.png)

The code works in all cases (phpunit tests all pass and is valid PHP)

Based on all these options, I selected the thing that seemed best to me.

 * It feels more natural to return `new static()` with the `static` return type
 * I didn't mind setting the classes as `final` where the constructor comes from the parent
 * I don't mind making the constructors `final` if either I have my own constructor or we were using the default constructor, though I'm not sure if it would just be better to make the class `final` in that case vs adding an empty `final` constructor.
 * I don't know if anything in here is testing `with*` methods correctly to use `static` return types
 
----

Happy to treat this as a discussion about what it would take to get something like this supported by EventSauce even if it means a lot more work on my part. :)

 * I doubt we could swing this in a minor release, but if that can happen, awesome
 * If we can work on a 2.x (`static` return types) release in parallel to 1.x (current mix of return types) I'd be up for helping to maintain that if the maintenance burden is the best reason against this