### PR TITLE
Remove type from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "eventsauce/eventsauce",
-    "type": "library",
     "description": "A pragmatic event sourcing library for PHP with a focus on developer experience.",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
This is the default and therefor not needed.