### PR TITLE
Publish subsplit packages for the 2.x line and update Composer packages

### DIFF
--- a/.github/workflows/publish-subsplits.yml
+++ b/.github/workflows/publish-subsplits.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - version/2.0
   create:
     tags:
       - '*'

--- a/src/CodeGeneration/composer.json
+++ b/src/CodeGeneration/composer.json
@@ -11,12 +11,17 @@
     ],
     "require": {
         "php": "^8.0",
-        "eventsauce/eventsauce": "^1.0",
+        "eventsauce/eventsauce": "^2.0",
         "symfony/yaml": "^5.0"
     },
     "autoload": {
         "psr-4": {
             "EventSauce\\EventSourcing\\CodeGeneration\\": "./"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-version/2.0": "2.x-dev"
         }
     }
 }

--- a/src/TestUtilities/composer.json
+++ b/src/TestUtilities/composer.json
@@ -11,12 +11,17 @@
     ],
     "require": {
         "php": "^8.0",
-        "eventsauce/eventsauce": "^1.0",
+        "eventsauce/eventsauce": "^2.0",
         "phpunit/phpunit": "^8.5|^9.4"
     },
     "autoload": {
         "psr-4": {
             "EventSauce\\EventSourcing\\TestUtilities\\": "./"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-version/2.0": "2.x-dev"
         }
     }
 }

--- a/src/UuidMessageDecorator/composer.json
+++ b/src/UuidMessageDecorator/composer.json
@@ -11,12 +11,17 @@
     ],
     "require": {
         "php": "^8.0",
-        "eventsauce/eventsauce": "^1.0",
+        "eventsauce/eventsauce": "^2.0",
         "ramsey/uuid": "^4.0"
     },
     "autoload": {
         "psr-4": {
             "EventSauce\\EventSourcing\\UuidMessageDecorator\\": "./"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-version/2.0": "2.x-dev"
         }
     }
 }


### PR DESCRIPTION
This finalizes the work started in #137 by adding branch aliases for the subsplit packages.

It also ensures the subsplit job kicks off for the `version/2.0` branch instead of just main so that the 2.x subsplit packages can exist in addition to just whatever is in `main`.

----

I don't really have the ability to test the workflow stuff since I'm not in the organization so I'm hoping this just works as-is. It *should*, but typically with changes to CI pipelines it takes me a few tries to get it right.

Desired goal:

 * When this is merged, it should kick off the subsplit project for the `version/2.0` branch
 * Since those projects now have the branch aliases set up we should see all three packages installable by targeting `^2`:
    * `eventsauce/code-generation:^2`
    * `eventsauce/test-utilities:^2`
    * `eventsauce/uuid-message-decorator:^2`
  * These packages will now also be compatible with the main `eventsauce/eventsauce` package.