### PR TITLE
RFC: Include Aggregate Root class name in message headers

### DIFF
--- a/src/EventSourcedAggregateRootRepositoryTest.php
+++ b/src/EventSourcedAggregateRootRepositoryTest.php
@@ -53,6 +53,6 @@ class EventSourcedAggregateRootRepositoryTest extends TestCase
         $messages = iterator_to_array($messageRepository->retrieveAll($aggregateRootId));
         self::assertEquals($expectedAggregateRootClassName, $messages[0]->aggregateRootClassName());
         self::assertEquals($expectedAggregateRootClassName, $messages[1]->aggregateRootClassName());
-        self::assertEquals($expectedAggregateRootClassName, $messages[2]->aggregateRootClassName());
+        self::assertEquals($expectedAggregateRootType, $messages[2]->aggregateRootClassName());
     }
 }

--- a/src/EventSourcedAggregateRootRepositoryTest.php
+++ b/src/EventSourcedAggregateRootRepositoryTest.php
@@ -51,8 +51,8 @@ class EventSourcedAggregateRootRepositoryTest extends TestCase
 
         /** @var Message[] $messages */
         $messages = iterator_to_array($messageRepository->retrieveAll($aggregateRootId));
-        self::assertEquals($expectedAggregateRootType, $messages[0]->aggregateRootClassName());
-        self::assertEquals($expectedAggregateRootType, $messages[1]->aggregateRootClassName());
-        self::assertEquals($expectedAggregateRootType, $messages[2]->aggregateRootClassName());
+        self::assertEquals($expectedAggregateRootType, $messages[0]->aggregateRootType());
+        self::assertEquals($expectedAggregateRootType, $messages[1]->aggregateRootType());
+        self::assertEquals($expectedAggregateRootType, $messages[2]->aggregateRootType());
     }
 }

--- a/src/EventSourcedAggregateRootRepositoryTest.php
+++ b/src/EventSourcedAggregateRootRepositoryTest.php
@@ -51,7 +51,7 @@ class EventSourcedAggregateRootRepositoryTest extends TestCase
 
         /** @var Message[] $messages */
         $messages = iterator_to_array($messageRepository->retrieveAll($aggregateRootId));
-        self::assertEquals($expectedAggregateRootClassName, $messages[0]->aggregateRootClassName());
+        self::assertEquals($expectedAggregateRootType, $messages[0]->aggregateRootClassName());
         self::assertEquals($expectedAggregateRootType, $messages[1]->aggregateRootClassName());
         self::assertEquals($expectedAggregateRootType, $messages[2]->aggregateRootClassName());
     }

--- a/src/EventSourcedAggregateRootRepositoryTest.php
+++ b/src/EventSourcedAggregateRootRepositoryTest.php
@@ -31,4 +31,28 @@ class EventSourcedAggregateRootRepositoryTest extends TestCase
         self::assertEquals(2, $messages[1]->aggregateVersion());
         self::assertEquals(3, $messages[2]->aggregateVersion());
     }
+
+    /**
+     * @test
+     */
+    public function aggregate_types_are_added_to_messages(): void
+    {
+        $messageRepository = new InMemoryMessageRepository();
+        $repository = new EventSourcedAggregateRootRepository(DummyAggregate::class, $messageRepository);
+        /** @var DummyAggregate $aggregate */
+        $aggregateRootId = DummyAggregateRootId::generate();
+        $aggregate = $repository->retrieve($aggregateRootId);
+        $aggregate->increment();
+        $aggregate->increment();
+        $aggregate->increment();
+        $repository->persist($aggregate);
+
+        $expectedAggregateRootClassName =  'event_sauce.event_sourcing.test_utilities.testing_aggregates.dummy_aggregate';
+
+        /** @var Message[] $messages */
+        $messages = iterator_to_array($messageRepository->retrieveAll($aggregateRootId));
+        self::assertEquals($expectedAggregateRootClassName, $messages[0]->aggregateRootClassName());
+        self::assertEquals($expectedAggregateRootClassName, $messages[1]->aggregateRootClassName());
+        self::assertEquals($expectedAggregateRootClassName, $messages[2]->aggregateRootClassName());
+    }
 }

--- a/src/EventSourcedAggregateRootRepositoryTest.php
+++ b/src/EventSourcedAggregateRootRepositoryTest.php
@@ -47,7 +47,7 @@ class EventSourcedAggregateRootRepositoryTest extends TestCase
         $aggregate->increment();
         $repository->persist($aggregate);
 
-        $expectedAggregateRootClassName =  'event_sauce.event_sourcing.test_utilities.testing_aggregates.dummy_aggregate';
+        $expectedAggregateRootType =  'event_sauce.event_sourcing.test_utilities.testing_aggregates.dummy_aggregate';
 
         /** @var Message[] $messages */
         $messages = iterator_to_array($messageRepository->retrieveAll($aggregateRootId));

--- a/src/EventSourcedAggregateRootRepositoryTest.php
+++ b/src/EventSourcedAggregateRootRepositoryTest.php
@@ -52,7 +52,7 @@ class EventSourcedAggregateRootRepositoryTest extends TestCase
         /** @var Message[] $messages */
         $messages = iterator_to_array($messageRepository->retrieveAll($aggregateRootId));
         self::assertEquals($expectedAggregateRootClassName, $messages[0]->aggregateRootClassName());
-        self::assertEquals($expectedAggregateRootClassName, $messages[1]->aggregateRootClassName());
+        self::assertEquals($expectedAggregateRootType, $messages[1]->aggregateRootClassName());
         self::assertEquals($expectedAggregateRootType, $messages[2]->aggregateRootClassName());
     }
 }

--- a/src/Header.php
+++ b/src/Header.php
@@ -11,5 +11,6 @@ interface Header
     public const TIME_OF_RECORDING = '__time_of_recording';
     public const AGGREGATE_ROOT_ID = '__aggregate_root_id';
     public const AGGREGATE_ROOT_ID_TYPE = '__aggregate_root_id_type';
+    public const AGGREGATE_ROOT_TYPE = '__aggregate_root_type';
     public const AGGREGATE_ROOT_VERSION = '__aggregate_root_version';
 }

--- a/src/Message.php
+++ b/src/Message.php
@@ -52,7 +52,7 @@ final class Message
         return $this->headers[Header::AGGREGATE_ROOT_ID] ?? null;
     }
 
-    public function aggregateRootClassName(): ?string
+    public function aggregateRootType(): ?string
     {
         return $this->headers[Header::AGGREGATE_ROOT_TYPE] ?? null;
     }

--- a/src/Message.php
+++ b/src/Message.php
@@ -52,6 +52,11 @@ final class Message
         return $this->headers[Header::AGGREGATE_ROOT_ID] ?? null;
     }
 
+    public function aggregateRootClassName(): ?string
+    {
+        return $this->headers[Header::AGGREGATE_ROOT_TYPE] ?? null;
+    }
+
     public function timeOfRecording(): DateTimeImmutable
     {
         /* @var DateTimeImmutable */


### PR DESCRIPTION
Discussion to see if it is feasible and desired to have Aggregate Root class name accessible from the message headers. There are a handful of places this information can be directly useful, especially when implementing a Message Repository where the underlying storage method may depend on the type of aggregate root being persisted.

Currently targeting the `main` base branch as this is possibly not a BC break and could be a part of 1.x and not just 2.x. Happy to change the base branch if `version/2.0` makes more sense.