### PR TITLE
Fix documentation: package name for Doctrine V2

### DIFF
--- a/docs/docs/message-storage/doctrine-2.md
+++ b/docs/docs/message-storage/doctrine-2.md
@@ -8,7 +8,7 @@ updated_at: 2021-08-24
 [![Packagist Version](https://img.shields.io/packagist/v/eventsauce/message-repository-for-doctrine-v2.svg?style=flat-square)](https://packagist.org/packages/eventsauce/message-repository-for-doctrine-v2)
 
 ```bash
-composer require eventsauce/message-repository-for-doctrine
+composer require eventsauce/message-repository-for-doctrine-v2
 ```
 
 ```php


### PR DESCRIPTION
The documentation page for the Doctrine V2 message repository used a `composer require` command that referenced the Doctrine V3 message repository package. This led to composer not being able to resolve to an installable set of packages. 

This MR fixes that by inserting the correct package name.