### PR TITLE
Attempt to set the source-branch for the subsplits from github.ref

### DIFF
--- a/.github/workflows/publish-subsplits.yml
+++ b/.github/workflows/publish-subsplits.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - version/2.0
   create:
     tags:
       - '*'

--- a/.github/workflows/publish-subsplits.yml
+++ b/.github/workflows/publish-subsplits.yml
@@ -20,6 +20,14 @@ jobs:
         with:
           fetch-depth: '0'
           persist-credentials: 'false'
+      - name: Get branch name (merge)
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
+      - name: Get branch name (pull request)
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF})" >> $GITHUB_ENV
       - uses: frankdejonge/use-github-token@1.0.1
         with:
           authentication: 'username:${{ secrets.PERSONAL_ACCESS_TOKEN }}'
@@ -33,7 +41,7 @@ jobs:
           key: '${{ runner.os }}-splitsh'
       - uses: frankdejonge/use-subsplit-publish@1.0.0-beta.2
         with:
-          source-branch: 'main'
+          source-branch: '${{ env.BRANCH_NAME }}'
           config-path: './config.subsplit-publish.json'
           splitsh-path: './.splitsh/splitsh-lite'
           splitsh-version: 'v1.0.1'

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-version/1.0.0": "1.x-dev"
+            "dev-version/2.0": "2.x-dev"
         }
     }
 }

--- a/docs/docs/reacting-to-events/process-managers.md
+++ b/docs/docs/reacting-to-events/process-managers.md
@@ -39,9 +39,9 @@ class ProductRestocker implements MessageConsumer
         $this->commandBus = $commandBus;
     }
 
-    public function handle(Message $message)
+    public function handle(Message $message): void
     {
-        $event = $message->event();
+        $event = $message->payload();
         
         if ($event instanceof ProductSoldOut) {
             $this->commandBus->handle(

--- a/docs/docs/reacting-to-events/projections-and-read-models.md
+++ b/docs/docs/reacting-to-events/projections-and-read-models.md
@@ -77,9 +77,9 @@ class PendingInvitationProjection implements MessageConsumer
         $this->invitations = $invitations;
     }
     
-    public function handle(Message $message)
+    public function handle(Message $message): void
     {
-        $event = $message->event();
+        $event = $message->payload();
         
         if ($event instanceof FriendshipRequestWasSent) {
             $this->invitations->add(new FriendshipRequest(

--- a/src/AggregateRootId.php
+++ b/src/AggregateRootId.php
@@ -8,5 +8,5 @@ interface AggregateRootId
 {
     public function toString(): string;
 
-    public static function fromString(string $aggregateRootId): self;
+    public static function fromString(string $aggregateRootId): static;
 }

--- a/src/CodeGeneration/CodeDumper.php
+++ b/src/CodeGeneration/CodeDumper.php
@@ -182,7 +182,7 @@ EOF;
         return <<<EOF
     public static function fromPayload(array \$payload): static
     {
-        return new $name($arguments);
+        return new static($arguments);
     }
 
     public function toPayload(): array

--- a/src/CodeGeneration/CodeDumper.php
+++ b/src/CodeGeneration/CodeDumper.php
@@ -180,7 +180,7 @@ EOF;
         }
 
         return <<<EOF
-    public static function fromPayload(array \$payload): self
+    public static function fromPayload(array \$payload): static
     {
         return new $name($arguments);
     }

--- a/src/CodeGeneration/Fixtures/commandsWithInterfaces.php
+++ b/src/CodeGeneration/Fixtures/commandsWithInterfaces.php
@@ -8,7 +8,7 @@ use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
 final class EventWithInterfaceMarker implements \EventSauce\EventSourcing\CodeGeneration\Fixtures\MarkerInterfaceStub, SerializablePayload
 {
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new EventWithInterfaceMarker();
     }
@@ -21,7 +21,7 @@ final class EventWithInterfaceMarker implements \EventSauce\EventSourcing\CodeGe
 
 final class CommandWithInterfaceMarker implements \EventSauce\EventSourcing\CodeGeneration\Fixtures\MarkerInterfaceStub, SerializablePayload
 {
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new CommandWithInterfaceMarker();
     }
@@ -34,7 +34,7 @@ final class CommandWithInterfaceMarker implements \EventSauce\EventSourcing\Code
 
 final class AlsoCommandWithInterfaceMarker implements \EventSauce\EventSourcing\CodeGeneration\Fixtures\MarkerInterfaceStub, SerializablePayload
 {
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new AlsoCommandWithInterfaceMarker();
     }

--- a/src/CodeGeneration/Fixtures/commandsWithInterfaces.php
+++ b/src/CodeGeneration/Fixtures/commandsWithInterfaces.php
@@ -10,7 +10,7 @@ final class EventWithInterfaceMarker implements \EventSauce\EventSourcing\CodeGe
 {
     public static function fromPayload(array $payload): static
     {
-        return new EventWithInterfaceMarker();
+        return new static();
     }
 
     public function toPayload(): array
@@ -23,7 +23,7 @@ final class CommandWithInterfaceMarker implements \EventSauce\EventSourcing\Code
 {
     public static function fromPayload(array $payload): static
     {
-        return new CommandWithInterfaceMarker();
+        return new static();
     }
 
     public function toPayload(): array
@@ -36,7 +36,7 @@ final class AlsoCommandWithInterfaceMarker implements \EventSauce\EventSourcing\
 {
     public static function fromPayload(array $payload): static
     {
-        return new AlsoCommandWithInterfaceMarker();
+        return new static();
     }
 
     public function toPayload(): array

--- a/src/CodeGeneration/Fixtures/definedWithYamlFixture.php
+++ b/src/CodeGeneration/Fixtures/definedWithYamlFixture.php
@@ -36,7 +36,7 @@ final class WeWentYamling implements SerializablePayload
         return $this->description;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new WeWentYamling(
             \Ramsey\Uuid\Uuid::fromString($payload['reference']),
@@ -104,7 +104,7 @@ final class HideFinancialDetailsOfFraudulentCompany implements SerializablePaylo
         return $this->companyId;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new HideFinancialDetailsOfFraudulentCompany(
             \Ramsey\Uuid\Uuid::fromString($payload['companyId'])
@@ -147,7 +147,7 @@ final class GoYamling implements SerializablePayload
         return $this->slogan;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new GoYamling(
             \Ramsey\Uuid\Uuid::fromString($payload['reference']),

--- a/src/CodeGeneration/Fixtures/definedWithYamlFixture.php
+++ b/src/CodeGeneration/Fixtures/definedWithYamlFixture.php
@@ -38,7 +38,7 @@ final class WeWentYamling implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new WeWentYamling(
+        return new static(
             \Ramsey\Uuid\Uuid::fromString($payload['reference']),
             (string) $payload['slogan'],
             (string) $payload['title'],
@@ -106,7 +106,7 @@ final class HideFinancialDetailsOfFraudulentCompany implements SerializablePaylo
 
     public static function fromPayload(array $payload): static
     {
-        return new HideFinancialDetailsOfFraudulentCompany(
+        return new static(
             \Ramsey\Uuid\Uuid::fromString($payload['companyId'])
         );
     }
@@ -149,7 +149,7 @@ final class GoYamling implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new GoYamling(
+        return new static(
             \Ramsey\Uuid\Uuid::fromString($payload['reference']),
             (string) $payload['slogan']
         );

--- a/src/CodeGeneration/Fixtures/definedWithoutHelpersInYamlFixture.php
+++ b/src/CodeGeneration/Fixtures/definedWithoutHelpersInYamlFixture.php
@@ -24,7 +24,7 @@ final class UserSubscribedFromMailingList implements SerializablePayload
         return $this->mailingList;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new UserSubscribedFromMailingList(
             (string) $payload['username'],
@@ -59,7 +59,7 @@ final class SubscribeToMailingList implements SerializablePayload
         return $this->mailingList;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new SubscribeToMailingList(
             (string) $payload['username'],
@@ -100,7 +100,7 @@ final class UnsubscribeFromMailingList implements SerializablePayload
         return $this->reason;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new UnsubscribeFromMailingList(
             (string) $payload['username'],

--- a/src/CodeGeneration/Fixtures/definedWithoutHelpersInYamlFixture.php
+++ b/src/CodeGeneration/Fixtures/definedWithoutHelpersInYamlFixture.php
@@ -26,7 +26,7 @@ final class UserSubscribedFromMailingList implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new UserSubscribedFromMailingList(
+        return new static(
             (string) $payload['username'],
             (string) $payload['mailingList']
         );
@@ -61,7 +61,7 @@ final class SubscribeToMailingList implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new SubscribeToMailingList(
+        return new static(
             (string) $payload['username'],
             (string) $payload['mailingList']
         );
@@ -102,7 +102,7 @@ final class UnsubscribeFromMailingList implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new UnsubscribeFromMailingList(
+        return new static(
             (string) $payload['username'],
             (string) $payload['mailingList'],
             (string) $payload['reason']

--- a/src/CodeGeneration/Fixtures/definitionGroupWithCommandFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithCommandFixture.php
@@ -20,7 +20,7 @@ final class DoSomething implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new DoSomething(
+        return new static(
             (string) $payload['reason']
         );
     }

--- a/src/CodeGeneration/Fixtures/definitionGroupWithCommandFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithCommandFixture.php
@@ -18,7 +18,7 @@ final class DoSomething implements SerializablePayload
         return $this->reason;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new DoSomething(
             (string) $payload['reason']

--- a/src/CodeGeneration/Fixtures/definitionGroupWithCommandTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithCommandTypePropertiesFixture.php
@@ -20,7 +20,7 @@ final class DoSomething implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new DoSomething(
+        return new static(
             (string) $payload['reason']
         );
     }

--- a/src/CodeGeneration/Fixtures/definitionGroupWithCommandTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithCommandTypePropertiesFixture.php
@@ -18,7 +18,7 @@ final class DoSomething implements SerializablePayload
         return $this->reason;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new DoSomething(
             (string) $payload['reason']

--- a/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsFixture.php
@@ -18,7 +18,7 @@ final class EventWithDescription implements SerializablePayload
         return $this->description;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new EventWithDescription(
             (string) $payload['description']

--- a/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsFixture.php
@@ -20,7 +20,7 @@ final class EventWithDescription implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new EventWithDescription(
+        return new static(
             (string) $payload['description']
         );
     }

--- a/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsTypePropertiesFixture.php
@@ -18,7 +18,7 @@ final class EventWithDescription implements SerializablePayload
         return $this->description;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new EventWithDescription(
             (string) $payload['description']

--- a/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionGroupWithDefaultsTypePropertiesFixture.php
@@ -20,7 +20,7 @@ final class EventWithDescription implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new EventWithDescription(
+        return new static(
             (string) $payload['description']
         );
     }

--- a/src/CodeGeneration/Fixtures/definitionWithFieldsFromOtherDefinitionsFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionWithFieldsFromOtherDefinitionsFixture.php
@@ -20,7 +20,7 @@ final class BaseEvent implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new BaseEvent(
+        return new static(
             (int) $payload['age']
         );
     }
@@ -47,7 +47,7 @@ final class ExtendedEvent implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new ExtendedEvent(
+        return new static(
             (int) $payload['age']
         );
     }
@@ -74,7 +74,7 @@ final class BaseCommand implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new BaseCommand(
+        return new static(
             (string) $payload['name']
         );
     }
@@ -101,7 +101,7 @@ final class ExtendedCommand implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new ExtendedCommand(
+        return new static(
             (string) $payload['name']
         );
     }

--- a/src/CodeGeneration/Fixtures/definitionWithFieldsFromOtherDefinitionsFixture.php
+++ b/src/CodeGeneration/Fixtures/definitionWithFieldsFromOtherDefinitionsFixture.php
@@ -18,7 +18,7 @@ final class BaseEvent implements SerializablePayload
         return $this->age;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new BaseEvent(
             (int) $payload['age']
@@ -45,7 +45,7 @@ final class ExtendedEvent implements SerializablePayload
         return $this->age;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new ExtendedEvent(
             (int) $payload['age']
@@ -72,7 +72,7 @@ final class BaseCommand implements SerializablePayload
         return $this->name;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new BaseCommand(
             (string) $payload['name']
@@ -99,7 +99,7 @@ final class ExtendedCommand implements SerializablePayload
         return $this->name;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new ExtendedCommand(
             (string) $payload['name']

--- a/src/CodeGeneration/Fixtures/groupWithEventWithNoFieldsFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithEventWithNoFieldsFixture.php
@@ -10,7 +10,7 @@ final class WithoutFields implements SerializablePayload
 {
     public static function fromPayload(array $payload): static
     {
-        return new WithoutFields();
+        return new static();
     }
 
     public function toPayload(): array

--- a/src/CodeGeneration/Fixtures/groupWithEventWithNoFieldsFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithEventWithNoFieldsFixture.php
@@ -8,7 +8,7 @@ use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
 final class WithoutFields implements SerializablePayload
 {
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new WithoutFields();
     }

--- a/src/CodeGeneration/Fixtures/groupWithEventWithNoFieldsTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithEventWithNoFieldsTypePropertiesFixture.php
@@ -10,7 +10,7 @@ final class WithoutFields implements SerializablePayload
 {
     public static function fromPayload(array $payload): static
     {
-        return new WithoutFields();
+        return new static();
     }
 
     public function toPayload(): array

--- a/src/CodeGeneration/Fixtures/groupWithEventWithNoFieldsTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithEventWithNoFieldsTypePropertiesFixture.php
@@ -8,7 +8,7 @@ use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
 final class WithoutFields implements SerializablePayload
 {
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new WithoutFields();
     }

--- a/src/CodeGeneration/Fixtures/groupWithEventWithTwoRequiredFieldsFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithEventWithTwoRequiredFieldsFixture.php
@@ -24,7 +24,7 @@ final class ThisOne implements SerializablePayload
         return $this->description;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new ThisOne(
             (string) $payload['title'],

--- a/src/CodeGeneration/Fixtures/groupWithEventWithTwoRequiredFieldsFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithEventWithTwoRequiredFieldsFixture.php
@@ -26,7 +26,7 @@ final class ThisOne implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new ThisOne(
+        return new static(
             (string) $payload['title'],
             (string) $payload['description']
         );

--- a/src/CodeGeneration/Fixtures/groupWithEventWithTwoRequiredFieldsTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithEventWithTwoRequiredFieldsTypePropertiesFixture.php
@@ -24,7 +24,7 @@ final class ThisOne implements SerializablePayload
         return $this->description;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new ThisOne(
             (string) $payload['title'],

--- a/src/CodeGeneration/Fixtures/groupWithEventWithTwoRequiredFieldsTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithEventWithTwoRequiredFieldsTypePropertiesFixture.php
@@ -26,7 +26,7 @@ final class ThisOne implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new ThisOne(
+        return new static(
             (string) $payload['title'],
             (string) $payload['description']
         );

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationFixture.php
@@ -20,7 +20,7 @@ final class WithFieldSerializers implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new WithFieldSerializers(
+        return new static(
             array_map(function ($property) {
                 return ['property' => $property];
             }, $payload['items'])

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationFixture.php
@@ -18,7 +18,7 @@ final class WithFieldSerializers implements SerializablePayload
         return $this->items;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new WithFieldSerializers(
             array_map(function ($property) {

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventFixture.php
@@ -18,7 +18,7 @@ final class EventName implements SerializablePayload
         return $this->title;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new EventName(
             strtolower($payload['title'])

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventFixture.php
@@ -20,7 +20,7 @@ final class EventName implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new EventName(
+        return new static(
             strtolower($payload['title'])
         );
     }

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventTypePropertiesFixture.php
@@ -18,7 +18,7 @@ final class EventName implements SerializablePayload
         return $this->title;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new EventName(
             strtolower($payload['title'])

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationFromEventTypePropertiesFixture.php
@@ -20,7 +20,7 @@ final class EventName implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new EventName(
+        return new static(
             strtolower($payload['title'])
         );
     }

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationTypePropertiesFixture.php
@@ -20,7 +20,7 @@ final class WithFieldSerializers implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new WithFieldSerializers(
+        return new static(
             array_map(function ($property) {
                 return ['property' => $property];
             }, $payload['items'])

--- a/src/CodeGeneration/Fixtures/groupWithFieldSerializationTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/groupWithFieldSerializationTypePropertiesFixture.php
@@ -18,7 +18,7 @@ final class WithFieldSerializers implements SerializablePayload
         return $this->items;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new WithFieldSerializers(
             array_map(function ($property) {

--- a/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupFixture.php
+++ b/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupFixture.php
@@ -20,7 +20,7 @@ final class FirstEvent implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new FirstEvent(
+        return new static(
             (string) $payload['firstField']
         );
     }
@@ -68,7 +68,7 @@ final class SecondEvent implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new SecondEvent(
+        return new static(
             (string) $payload['secondField']
         );
     }

--- a/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupFixture.php
+++ b/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupFixture.php
@@ -18,7 +18,7 @@ final class FirstEvent implements SerializablePayload
         return $this->firstField;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new FirstEvent(
             (string) $payload['firstField']
@@ -66,7 +66,7 @@ final class SecondEvent implements SerializablePayload
         return $this->secondField;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new SecondEvent(
             (string) $payload['secondField']

--- a/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupTypePropertiesFixture.php
@@ -20,7 +20,7 @@ final class FirstEvent implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new FirstEvent(
+        return new static(
             (string) $payload['firstField']
         );
     }
@@ -68,7 +68,7 @@ final class SecondEvent implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new SecondEvent(
+        return new static(
             (string) $payload['secondField']
         );
     }

--- a/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/multipleEventsDefinitionGroupTypePropertiesFixture.php
@@ -18,7 +18,7 @@ final class FirstEvent implements SerializablePayload
         return $this->firstField;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new FirstEvent(
             (string) $payload['firstField']
@@ -66,7 +66,7 @@ final class SecondEvent implements SerializablePayload
         return $this->secondField;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new SecondEvent(
             (string) $payload['secondField']

--- a/src/CodeGeneration/Fixtures/simpleDefinitionGroupFixture.php
+++ b/src/CodeGeneration/Fixtures/simpleDefinitionGroupFixture.php
@@ -26,7 +26,7 @@ final class SomethingHappened implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new SomethingHappened(
+        return new static(
             (string) $payload['what'],
             (bool) $payload['yolo']
         );

--- a/src/CodeGeneration/Fixtures/simpleDefinitionGroupFixture.php
+++ b/src/CodeGeneration/Fixtures/simpleDefinitionGroupFixture.php
@@ -24,7 +24,7 @@ final class SomethingHappened implements SerializablePayload
         return $this->yolo;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new SomethingHappened(
             (string) $payload['what'],

--- a/src/CodeGeneration/Fixtures/simpleDefinitionGroupTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/simpleDefinitionGroupTypePropertiesFixture.php
@@ -26,7 +26,7 @@ final class SomethingHappened implements SerializablePayload
 
     public static function fromPayload(array $payload): static
     {
-        return new SomethingHappened(
+        return new static(
             (string) $payload['what'],
             (bool) $payload['yolo']
         );

--- a/src/CodeGeneration/Fixtures/simpleDefinitionGroupTypePropertiesFixture.php
+++ b/src/CodeGeneration/Fixtures/simpleDefinitionGroupTypePropertiesFixture.php
@@ -24,7 +24,7 @@ final class SomethingHappened implements SerializablePayload
         return $this->yolo;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new SomethingHappened(
             (string) $payload['what'],

--- a/src/CodeGeneration/PayloadDefinition.php
+++ b/src/CodeGeneration/PayloadDefinition.php
@@ -27,14 +27,14 @@ final class PayloadDefinition
     /**
      * @return $this
      */
-    public function withFieldsFrom(string $otherType): self
+    public function withFieldsFrom(string $otherType): static
     {
         $this->fieldsFrom = $otherType;
 
         return $this;
     }
 
-    public function withInterface(string $interface): self
+    public function withInterface(string $interface): static
     {
         $this->interfaces[] = $interface;
 
@@ -56,7 +56,7 @@ final class PayloadDefinition
         return $this->fieldsFrom;
     }
 
-    public function field(string $name, string $type, string $example = null, ?bool $nullable = null): self
+    public function field(string $name, string $type, string $example = null, ?bool $nullable = null): static
     {
         $example = $example ?: $this->group->exampleForField($name);
         $this->fields[] = compact('name', 'type', 'example', 'nullable');
@@ -64,7 +64,7 @@ final class PayloadDefinition
         return $this;
     }
 
-    public function fieldSerializer(string $field, string $template): self
+    public function fieldSerializer(string $field, string $template): static
     {
         $this->fieldSerializers[$field] = $template;
 
@@ -76,7 +76,7 @@ final class PayloadDefinition
         return $this->fieldSerializers[$field] ?? $this->group->serializerForField($field);
     }
 
-    public function fieldDeserializer(string $field, string $template): self
+    public function fieldDeserializer(string $field, string $template): static
     {
         $this->fieldDeserializers[$field] = $template;
 

--- a/src/CodeGeneration/composer.json
+++ b/src/CodeGeneration/composer.json
@@ -11,12 +11,17 @@
     ],
     "require": {
         "php": "^8.0",
-        "eventsauce/eventsauce": "^1.0",
+        "eventsauce/eventsauce": "^2.0",
         "symfony/yaml": "^5.0"
     },
     "autoload": {
         "psr-4": {
             "EventSauce\\EventSourcing\\CodeGeneration\\": "./"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-version/2.0": "2.x-dev"
         }
     }
 }

--- a/src/DefaultHeadersDecorator.php
+++ b/src/DefaultHeadersDecorator.php
@@ -22,7 +22,7 @@ class DefaultHeadersDecorator implements MessageDecorator
     {
         return $message->withHeader(
             Header::EVENT_TYPE,
-            $this->inflector->instanceToType($message->event())
+            $this->inflector->instanceToType($message->payload())
         )->withTimeOfRecording($this->clock->now());
     }
 }

--- a/src/DummyAggregateRootId.php
+++ b/src/DummyAggregateRootId.php
@@ -26,10 +26,7 @@ final class DummyAggregateRootId implements AggregateRootId
         return new DummyAggregateRootId(bin2hex(random_bytes(25)));
     }
 
-    /**
-     * @return static
-     */
-    public static function fromString(string $aggregateRootId): AggregateRootId
+    public static function fromString(string $aggregateRootId): static
     {
         return new static($aggregateRootId);
     }

--- a/src/DummyEvent.php
+++ b/src/DummyEvent.php
@@ -6,15 +6,15 @@ namespace EventSauce\EventSourcing;
 
 use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-class DummyEvent implements SerializablePayload
+final class DummyEvent implements SerializablePayload
 {
     public function toPayload(): array
     {
         return [];
     }
 
-    public static function fromPayload(array $payload): SerializablePayload
+    public static function fromPayload(array $payload): static
     {
-        return new DummyEvent();
+        return new static();
     }
 }

--- a/src/EventConsumer.php
+++ b/src/EventConsumer.php
@@ -8,7 +8,7 @@ abstract class EventConsumer implements MessageConsumer
 {
     public function handle(Message $message): void
     {
-        $event = $message->event();
+        $event = $message->payload();
         $parts = explode('\\', get_class($event));
         $method = 'handle' . end($parts);
 

--- a/src/EventHandlingMessageConsumer.php
+++ b/src/EventHandlingMessageConsumer.php
@@ -13,7 +13,7 @@ class EventHandlingMessageConsumer implements MessageConsumer
 {
     public function handle(Message $message): void
     {
-        $event = $message->event();
+        $event = $message->payload();
         $parts = explode('\\', get_class($event));
         $method = 'handle' . end($parts);
 

--- a/src/EventStub.php
+++ b/src/EventStub.php
@@ -33,13 +33,13 @@ final class EventStub implements SerializablePayload
         return $this->value;
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
-        return new self($payload['value']);
+        return new static($payload['value']);
     }
 
-    public static function create(string $value = null): self
+    public static function create(string $value = null): static
     {
-        return self::fromPayload(compact('value'));
+        return static::fromPayload(compact('value'));
     }
 }

--- a/src/InMemoryMessageRepository.php
+++ b/src/InMemoryMessageRepository.php
@@ -38,7 +38,7 @@ final class InMemoryMessageRepository implements MessageRepository
         /** @var Message $message */
         foreach ($messages as $message) {
             $this->messages[] = $message;
-            $this->lastCommit[] = $message->event();
+            $this->lastCommit[] = $message->payload();
         }
     }
 

--- a/src/LibraryConsumptionTests/ComplexAggregates/DelegatedActionWasPerformed.php
+++ b/src/LibraryConsumptionTests/ComplexAggregates/DelegatedActionWasPerformed.php
@@ -17,7 +17,7 @@ class DelegatedActionWasPerformed implements SerializablePayload
         return ['counter' => $this->counter];
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new DelegatedActionWasPerformed($payload['counter']);
     }

--- a/src/LibraryConsumptionTests/ComplexAggregates/DelegatedAggregateWasChosen.php
+++ b/src/LibraryConsumptionTests/ComplexAggregates/DelegatedAggregateWasChosen.php
@@ -13,7 +13,7 @@ class DelegatedAggregateWasChosen implements SerializablePayload
         return [];
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new DelegatedAggregateWasChosen();
     }

--- a/src/LibraryConsumptionTests/ComplexAggregates/DelegatedAggregateWasDiscarded.php
+++ b/src/LibraryConsumptionTests/ComplexAggregates/DelegatedAggregateWasDiscarded.php
@@ -13,7 +13,7 @@ class DelegatedAggregateWasDiscarded implements SerializablePayload
         return [];
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new DelegatedAggregateWasDiscarded();
     }

--- a/src/LibraryConsumptionTests/DecoratingMessages/MessageDecoratingTest.php
+++ b/src/LibraryConsumptionTests/DecoratingMessages/MessageDecoratingTest.php
@@ -20,7 +20,7 @@ class MessageDecoratingTest extends TestCase
         $event = new EventStub('value');
         $message = new Message($event);
         $decoratedMessage = $decorator->decorate($message);
-        $this->assertEquals($event, $decoratedMessage->event());
+        $this->assertEquals($event, $decoratedMessage->payload());
         $this->assertEquals('value', $decoratedMessage->header('dummy'));
     }
 }

--- a/src/LibraryConsumptionTests/RequiringHistoryWithAggregateRootConstruction/AggregateThatRequiredHistoryForReconstitutionStub.php
+++ b/src/LibraryConsumptionTests/RequiringHistoryWithAggregateRootConstruction/AggregateThatRequiredHistoryForReconstitutionStub.php
@@ -15,7 +15,7 @@ final class AggregateThatRequiredHistoryForReconstitutionStub implements Aggrega
 {
     use AggregateRootBehaviourWithRequiredHistory;
 
-    public static function start(DummyAggregateRootId $id): self
+    public static function start(DummyAggregateRootId $id): static
     {
         $aggregate = new static($id);
         $aggregate->recordThat(new DummyInternalEvent());

--- a/src/Message.php
+++ b/src/Message.php
@@ -11,7 +11,7 @@ final class Message
 {
     public const TIME_OF_RECORDING_FORMAT = 'Y-m-d H:i:s.uO';
 
-    public function __construct(private object $event, private array $headers = [])
+    public function __construct(private object $payload, private array $headers = [])
     {
     }
 
@@ -82,8 +82,16 @@ final class Message
         return $this->headers;
     }
 
+    public function payload(): object
+    {
+        return $this->payload;
+    }
+
+    /**
+     * @deprecated use ->payload instead
+     */
     public function event(): object
     {
-        return $this->event;
+        return $this->payload;
     }
 }

--- a/src/MessageDispatchingEventDispatcherTest.php
+++ b/src/MessageDispatchingEventDispatcherTest.php
@@ -18,7 +18,7 @@ class MessageDispatchingEventDispatcherTest extends TestCase
         $event = new EventStub('value');
         $eventDispatcher->dispatch($event);
         $collectedMessages = $subdispatcher->collectedMessages();
-        $this->assertEquals($event, $collectedMessages[0]->event());
+        $this->assertEquals($event, $collectedMessages[0]->payload());
     }
 
     /**

--- a/src/MessageTest.php
+++ b/src/MessageTest.php
@@ -21,7 +21,7 @@ class MessageTest extends TestCase
         $event = EventStub::create('some value');
         $initialHeaders = ['initial' => 'header value'];
         $message = new Message($event, $initialHeaders);
-        $this->assertSame($event, $message->event());
+        $this->assertSame($event, $message->payload());
         $this->assertEquals($initialHeaders, $message->headers());
     }
 

--- a/src/Serialization/ConstructingMessageSerializer.php
+++ b/src/Serialization/ConstructingMessageSerializer.php
@@ -25,7 +25,7 @@ final class ConstructingMessageSerializer implements MessageSerializer
 
     public function serializeMessage(Message $message): array
     {
-        $event = $message->event();
+        $event = $message->payload();
         $payload = $this->payloadSerializer->serializePayload($event);
         $headers = $message->headers();
         $headers[Header::EVENT_TYPE] ??= $this->classNameInflector->instanceToType($event);

--- a/src/Serialization/SerializablePayload.php
+++ b/src/Serialization/SerializablePayload.php
@@ -8,5 +8,5 @@ interface SerializablePayload
 {
     public function toPayload(): array;
 
-    public static function fromPayload(array $payload): self;
+    public static function fromPayload(array $payload): static;
 }

--- a/src/Snapshotting/ConstructingAggregateRootRepositoryWithSnapshotting.php
+++ b/src/Snapshotting/ConstructingAggregateRootRepositoryWithSnapshotting.php
@@ -57,7 +57,7 @@ final class ConstructingAggregateRootRepositoryWithSnapshotting implements Aggre
         $messages = $this->messageRepository->retrieveAllAfterVersion($aggregateRootId, $version);
 
         foreach ($messages as $message) {
-            yield $message->event();
+            yield $message->payload();
         }
 
         return $messages->getReturn();

--- a/src/Snapshotting/Tests/LightSwitchId.php
+++ b/src/Snapshotting/Tests/LightSwitchId.php
@@ -17,7 +17,7 @@ final class LightSwitchId implements AggregateRootId
         return $this->id;
     }
 
-    public static function fromString(string $aggregateRootId): AggregateRootId
+    public static function fromString(string $aggregateRootId): static
     {
         return new static($aggregateRootId);
     }

--- a/src/Snapshotting/Tests/LightSwitchWasFlipped.php
+++ b/src/Snapshotting/Tests/LightSwitchWasFlipped.php
@@ -26,14 +26,14 @@ final class LightSwitchWasFlipped implements SerializablePayload
         return $this->state;
     }
 
-    public static function on(): self
+    public static function on(): static
     {
         return new static(self::ON);
     }
 
-    public static function off(): self
+    public static function off(): static
     {
-        return new self(self::OFF);
+        return new static(self::OFF);
     }
 
     public function toPayload(): array
@@ -41,8 +41,8 @@ final class LightSwitchWasFlipped implements SerializablePayload
         return ['state' => $this->state];
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
-        return new self($payload['state']);
+        return new static($payload['state']);
     }
 }

--- a/src/TestUtilities/MessageConsumerThatSerializesMessages.php
+++ b/src/TestUtilities/MessageConsumerThatSerializesMessages.php
@@ -26,6 +26,6 @@ class MessageConsumerThatSerializesMessages implements MessageConsumer
     {
         $payload = $this->serializer->serializeMessage($message);
         $deserializedMessage = $this->serializer->unserializePayload($payload);
-        TestCase::assertEquals($message->event(), $deserializedMessage->event());
+        TestCase::assertEquals($message->payload(), $deserializedMessage->payload());
     }
 }

--- a/src/TestUtilities/TestingAggregates/AggregateWasInitiated.php
+++ b/src/TestUtilities/TestingAggregates/AggregateWasInitiated.php
@@ -13,7 +13,7 @@ final class AggregateWasInitiated implements SerializablePayload
         return [];
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
         return new static();
     }

--- a/src/TestUtilities/TestingAggregates/DummyIncrementingHappened.php
+++ b/src/TestUtilities/TestingAggregates/DummyIncrementingHappened.php
@@ -14,7 +14,7 @@ class DummyIncrementingHappened implements SerializablePayload
 {
     private int $number;
 
-    public function __construct(int $number)
+    final public function __construct(int $number)
     {
         $this->number = $number;
     }
@@ -24,9 +24,9 @@ class DummyIncrementingHappened implements SerializablePayload
         return ['number' => $this->number];
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
-        return new DummyIncrementingHappened($payload['number']);
+        return new static($payload['number']);
     }
 
     public function number(): int

--- a/src/TestUtilities/TestingAggregates/DummyTaskWasExecuted.php
+++ b/src/TestUtilities/TestingAggregates/DummyTaskWasExecuted.php
@@ -10,12 +10,8 @@ use EventSauce\EventSourcing\Serialization\SerializablePayload;
  * @codeCoverageIgnore
  * @testAsset
  */
-class DummyTaskWasExecuted implements SerializablePayload
+final class DummyTaskWasExecuted implements SerializablePayload
 {
-    final public function __construct()
-    {
-    }
-
     public function toPayload(): array
     {
         return [];

--- a/src/TestUtilities/TestingAggregates/DummyTaskWasExecuted.php
+++ b/src/TestUtilities/TestingAggregates/DummyTaskWasExecuted.php
@@ -12,13 +12,17 @@ use EventSauce\EventSourcing\Serialization\SerializablePayload;
  */
 class DummyTaskWasExecuted implements SerializablePayload
 {
+    final public function __construct()
+    {
+    }
+
     public function toPayload(): array
     {
         return [];
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
-        return new self();
+        return new static();
     }
 }

--- a/src/TestUtilities/composer.json
+++ b/src/TestUtilities/composer.json
@@ -11,12 +11,17 @@
     ],
     "require": {
         "php": "^8.0",
-        "eventsauce/eventsauce": "^1.0",
+        "eventsauce/eventsauce": "^2.0",
         "phpunit/phpunit": "^8.5|^9.4"
     },
     "autoload": {
         "psr-4": {
             "EventSauce\\EventSourcing\\TestUtilities\\": "./"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-version/2.0": "2.x-dev"
         }
     }
 }

--- a/src/UnableToDispatchMessages.php
+++ b/src/UnableToDispatchMessages.php
@@ -7,10 +7,10 @@ namespace EventSauce\EventSourcing;
 use RuntimeException;
 use Throwable;
 
-class UnableToDispatchMessages extends RuntimeException implements EventSauceException
+final class UnableToDispatchMessages extends RuntimeException implements EventSauceException
 {
-    public static function dueTo(string $reason, Throwable $previous = null): self
+    public static function dueTo(string $reason, Throwable $previous = null): static
     {
-        return new self("Unable to dispatch messages. {$reason}", 0, $previous);
+        return new static("Unable to dispatch messages. {$reason}", 0, $previous);
     }
 }

--- a/src/UnableToPersistMessages.php
+++ b/src/UnableToPersistMessages.php
@@ -9,8 +9,8 @@ use Throwable;
 
 final class UnableToPersistMessages extends RuntimeException implements EventSauceException
 {
-    public static function dueTo(string $reason, Throwable $previous = null): self
+    public static function dueTo(string $reason, Throwable $previous = null): static
     {
-        return new self("Unable to persist messages. {$reason}", 0, $previous);
+        return new static("Unable to persist messages. {$reason}", 0, $previous);
     }
 }

--- a/src/UnableToResolveTimeOfRecording.php
+++ b/src/UnableToResolveTimeOfRecording.php
@@ -8,8 +8,8 @@ use RuntimeException;
 
 final class UnableToResolveTimeOfRecording extends RuntimeException implements EventSauceException
 {
-    public static function fromFormatAndHeader(string $format, mixed $header): self
+    public static function fromFormatAndHeader(string $format, mixed $header): static
     {
-        return new self("Unable to determine time of recording from format \"{$format}\" and header \"{$header}\"");
+        return new static("Unable to determine time of recording from format \"{$format}\" and header \"{$header}\"");
     }
 }

--- a/src/UnableToRetrieveMessages.php
+++ b/src/UnableToRetrieveMessages.php
@@ -7,10 +7,10 @@ namespace EventSauce\EventSourcing;
 use RuntimeException;
 use Throwable;
 
-class UnableToRetrieveMessages extends RuntimeException implements EventSauceException
+final class UnableToRetrieveMessages extends RuntimeException implements EventSauceException
 {
-    public static function dueTo(string $reason, Throwable $previous = null): self
+    public static function dueTo(string $reason, Throwable $previous = null): static
     {
-        return new self("Unable to retrieve messages. {$reason}", 0, $previous);
+        return new static("Unable to retrieve messages. {$reason}", 0, $previous);
     }
 }

--- a/src/Upcasting/UpcastedPayloadStub.php
+++ b/src/Upcasting/UpcastedPayloadStub.php
@@ -9,7 +9,7 @@ use EventSauce\EventSourcing\Serialization\SerializablePayload;
 /**
  * @testAsset
  */
-class UpcastedPayloadStub implements SerializablePayload
+final class UpcastedPayloadStub implements SerializablePayload
 {
     private string $property;
 
@@ -23,8 +23,8 @@ class UpcastedPayloadStub implements SerializablePayload
         return ['property' => $this->property];
     }
 
-    public static function fromPayload(array $payload): self
+    public static function fromPayload(array $payload): static
     {
-        return new UpcastedPayloadStub($payload['property'] ?? 'undefined');
+        return new static($payload['property'] ?? 'undefined');
     }
 }

--- a/src/UuidMessageDecorator/composer.json
+++ b/src/UuidMessageDecorator/composer.json
@@ -11,12 +11,17 @@
     ],
     "require": {
         "php": "^8.0",
-        "eventsauce/eventsauce": "^1.0",
+        "eventsauce/eventsauce": "^2.0",
         "ramsey/uuid": "^4.0"
     },
     "autoload": {
         "psr-4": {
             "EventSauce\\EventSourcing\\UuidMessageDecorator\\": "./"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-version/2.0": "2.x-dev"
         }
     }
 }


### PR DESCRIPTION
Thank you so much for merging #140!!!

It looks like it [actually tried to run on the `version/2.0` branch](https://github.com/EventSaucePHP/EventSauce/actions/runs/1473686640) which is GREAT! Unfortunately, it seems like it [rebuilt the subsplits for the main branch instead](https://github.com/EventSaucePHP/EventSauce/runs/4243870931?check_suite_focus=true#step:5:290).

I wanted to see if I could figure out what was wrong before asking you about it. From what I've discovered, [`main` is hardcoded into the workflow](https://github.com/EventSaucePHP/EventSauce/blob/main/.github/workflows/publish-subsplits.yml#L35). This means even though the workflow triggers for both `main` and `version/2.0`, it's still running splitsh against `main` regardless.

Getting the branch name and setting the `source-branch` from the GitHub Actions environment is the most straightforward approach. That's what this PR aims to do. Here is the proof of concepts showing that both `refs/heads/main` and `refs/heads/version/2.0` both work:

```
(\
  GITHUB_REF=refs/heads/main; \
  BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/}); \
  echo $BRANCH_NAME\
)
# Output: main


(\
  GITHUB_REF=refs/heads/version/2.0; \
  BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/}); \
  echo $BRANCH_NAME\
)
# Output: version/2.0
```

A longer-term approach would be to bake this logic into `frankdejonge/use-subsplit-publish.` `source-branch` could become optional and derived from `github.ref` if not explicitly overridden.

https://github.com/frankdejonge/use-subsplit-publish/blob/main/index.ts#L126

If you like that idea in general, let me know! I can see about adding that functionality to that action later.

----

My bad for the noise on this. It is not easy working on these CI things from the outside. Hopefully, there will not be too much more work to get the 2.x subsplits working.