### PR TITLE
Array lookup based class inflection

### DIFF
--- a/docs/docs/advanced/message-internals.md
+++ b/docs/docs/advanced/message-internals.md
@@ -44,3 +44,22 @@ serializes the event to the following format (shown JSON encoded):
 
 If needed you can create a custom implementation of the `MessageSerializer` to adapt to
 existing serialization formats in your application or in systems you interact with.
+
+### Class name inflection
+
+By default, the `ContructionMessageSerializer` uses the `DotSeparatedSnakeCaseInflector` to 
+convert event and id class names to a string when storing an event. And to return the class from 
+a string when reconstructing the event from the repository.
+
+This couples the event's implementation details to the event storage, making it hard to refactor the Name or namespace 
+of the event. 
+
+The `ArrayLookupClassNameInflector` could be used to declare a map from event to string.
+
+```php
+    new ConstructingMessageSerializer(
+        new \EventSauce\EventSourcing\ArrayLookupClassNameInflector([
+            'TransactionRecorded' => TransactionRecorded::class
+        ])
+    )
+```

--- a/docs/docs/advanced/message-internals.md
+++ b/docs/docs/advanced/message-internals.md
@@ -48,11 +48,16 @@ existing serialization formats in your application or in systems you interact wi
 ### Class name inflection
 
 By default, the `ContructionMessageSerializer` uses the `DotSeparatedSnakeCaseInflector` to 
-convert event and id class names to a string when storing an event. And to return the class from 
-a string when reconstructing the event from the repository.
+convert event and id class names to a string when storing an event. When reconstructing the 
+event from the repository it than used the class again to construct the get the FQN from the string.
+
+For example:
+
+`Domain\BankAccount\DomainEvents\TransactionRecorded::class` becomes `Domain.bank_account.domain_events.transaction_recorded` in the database.
+
 
 This couples the event's implementation details to the event storage, making it hard to refactor the Name or namespace 
-of the event. 
+of the event.
 
 The `ArrayLookupClassNameInflector` could be used to declare a map from event to string.
 
@@ -63,3 +68,6 @@ The `ArrayLookupClassNameInflector` could be used to declare a map from event to
         ])
     )
 ```
+
+This method allows us to freely rename or move event classes.
+A downside for this method, is that you need to be sure the class name is configured in lookup array.

--- a/src/ArrayLookupClassNameInflector.php
+++ b/src/ArrayLookupClassNameInflector.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing;
 
 class ArrayLookupClassNameInflector implements ClassNameInflector
 {
-
     public function __construct(protected array $lookup)
     {
     }
@@ -12,17 +13,19 @@ class ArrayLookupClassNameInflector implements ClassNameInflector
     public function classNameToType(string $className): string
     {
         $type = array_search($className, $this->lookup);
-        if($type === false){
+        if ($type === false) {
             throw new \Exception("Configure {$className} in event type lookup");
         }
+
         return $type;
     }
 
     public function typeToClassName(string $eventType): string
     {
-        if (!array_key_exists($eventType, $this->lookup)) {
+        if ( ! array_key_exists($eventType, $this->lookup)) {
             throw new \Exception("Type '{$eventType}' not configured in event type lookup");
         }
+
         return $this->lookup[$eventType];
     }
 

--- a/src/ArrayLookupClassNameInflector.php
+++ b/src/ArrayLookupClassNameInflector.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace EventSauce\EventSourcing;
+
+class ArrayLookupClassNameInflector implements ClassNameInflector
+{
+
+    public function __construct(protected array $lookup)
+    {
+    }
+
+    public function classNameToType(string $className): string
+    {
+        $type = array_search($className, $this->lookup);
+        if($type === false){
+            throw new \Exception("Configure {$className} in event type lookup");
+        }
+        return $type;
+    }
+
+    public function typeToClassName(string $eventType): string
+    {
+        if (!array_key_exists($eventType, $this->lookup)) {
+            throw new \Exception("Type '{$eventType}' not configured in event type lookup");
+        }
+        return $this->lookup[$eventType];
+    }
+
+    public function instanceToType(object $instance): string
+    {
+        return $this->classNameToType(get_class($instance));
+    }
+}

--- a/src/ArrayLookupClassNameInflectorTest.php
+++ b/src/ArrayLookupClassNameInflectorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing;
 
 use PHPUnit\Framework\TestCase;
@@ -7,36 +9,36 @@ use PHPUnit\Framework\TestCase;
 class ArrayLookupClassNameInflectorTest extends TestCase
 {
     /** @test */
-    public function it_can_lookup_a_class_name_and_return_the_configured_name()
+    public function it_can_lookup_a_class_name_and_return_the_configured_name(): void
     {
         $inflector = new ArrayLookupClassNameInflector([
-            'test_event' => TestEvent::class
+            'test_event' => TestEvent::class,
         ]);
 
         $this->assertEquals('test_event', $inflector->classNameToType(TestEvent::class));
     }
 
     /** @test */
-    public function it_throws_an_exception_when_lookup_is_not_configured()
+    public function it_throws_an_exception_when_lookup_is_not_configured(): void
     {
         $inflector = new ArrayLookupClassNameInflector([]);
 
-        $this->expectExceptionObject(new \Exception("Configure ".TestEvent::class." in event type lookup"));
+        $this->expectExceptionObject(new \Exception('Configure ' . TestEvent::class . ' in event type lookup'));
         $inflector->classNameToType(TestEvent::class);
     }
 
     /** @test */
-    public function it_can_retrieve_the_class_name_from_type()
+    public function it_can_retrieve_the_class_name_from_type(): void
     {
         $inflector = new ArrayLookupClassNameInflector([
-            'test_event' => TestEvent::class
+            'test_event' => TestEvent::class,
         ]);
 
         $this->assertEquals(TestEvent::class, $inflector->typeToClassName('test_event'));
     }
 
     /** @test */
-    public function it_throws_an_exception_when_class_cannot_be_found()
+    public function it_throws_an_exception_when_class_cannot_be_found(): void
     {
         $inflector = new ArrayLookupClassNameInflector([]);
 
@@ -45,10 +47,10 @@ class ArrayLookupClassNameInflectorTest extends TestCase
     }
 
     /** @test */
-    public function it_works_with_instance_to_type()
+    public function it_works_with_instance_to_type(): void
     {
         $inflector = new ArrayLookupClassNameInflector([
-            'test_event' => TestEvent::class
+            'test_event' => TestEvent::class,
         ]);
         $event = new TestEvent();
 
@@ -58,5 +60,4 @@ class ArrayLookupClassNameInflectorTest extends TestCase
 
 class TestEvent
 {
-
 }

--- a/src/ArrayLookupClassNameInflectorTest.php
+++ b/src/ArrayLookupClassNameInflectorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace EventSauce\EventSourcing;
+
+use PHPUnit\Framework\TestCase;
+
+class ArrayLookupClassNameInflectorTest extends TestCase
+{
+    /** @test */
+    public function it_can_lookup_a_class_name_and_return_the_configured_name()
+    {
+        $inflector = new ArrayLookupClassNameInflector([
+            'test_event' => TestEvent::class
+        ]);
+
+        $this->assertEquals('test_event', $inflector->classNameToType(TestEvent::class));
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_lookup_is_not_configured()
+    {
+        $inflector = new ArrayLookupClassNameInflector([]);
+
+        $this->expectExceptionObject(new \Exception("Configure ".TestEvent::class." in event type lookup"));
+        $inflector->classNameToType(TestEvent::class);
+    }
+
+    /** @test */
+    public function it_can_retrieve_the_class_name_from_type()
+    {
+        $inflector = new ArrayLookupClassNameInflector([
+            'test_event' => TestEvent::class
+        ]);
+
+        $this->assertEquals(TestEvent::class, $inflector->typeToClassName('test_event'));
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_class_cannot_be_found()
+    {
+        $inflector = new ArrayLookupClassNameInflector([]);
+
+        $this->expectExceptionObject(new \Exception("Type 'test_event' not configured in event type lookup"));
+        $inflector->typeToClassName('test_event');
+    }
+
+    /** @test */
+    public function it_works_with_instance_to_type()
+    {
+        $inflector = new ArrayLookupClassNameInflector([
+            'test_event' => TestEvent::class
+        ]);
+        $event = new TestEvent();
+
+        $this->assertEquals('test_event', $inflector->instanceToType($event));
+    }
+}
+
+class TestEvent
+{
+
+}


### PR DESCRIPTION
By default, the `ContructionMessageSerializer` uses the `DotSeparatedSnakeCaseInflector` to 
convert event and id class names to a string when storing an event. And to return the class from 
a string when reconstructing the event from the repository.

This couples the event's implementation details to the event storage, making it hard to refactor the Name or namespace 
of the event. (We'd have to implement our own inflector with the "changes" or update our event stream 😱 )

The `ArrayLookupClassNameInflector` could be used to declare a map from event to string.

```php
    new ConstructingMessageSerializer(
        new \EventSauce\EventSourcing\ArrayLookupClassNameInflector([
            'TransactionRecorded' => TransactionRecorded::class
        ])
    )
```


I think it's a good UX to include this in the package. Also happy to create a separate package for when this is not the case.


Note that the example construction of the class is a bit naive. When using EventSauce in a Laravel project, for example, you'd configure the array class to pass using dependency injection. Or using a config on the AggregateRootRepository. 