### PR TITLE
Rebuild projection example

### DIFF
--- a/config.subsplit-publish.json
+++ b/config.subsplit-publish.json
@@ -14,6 +14,11 @@
             "name": "testing",
             "directory": "src/TestUtilities",
             "target": "git@github.com:EventSaucePHP/TestUtilities.git"
+        },
+        {
+            "name": "replay-consumer",
+            "directory": "src/ReplayConsumer",
+            "target": "git@github.com:EventSaucePHP/ReplayConsumer.git"
         }
     ]
 }

--- a/docs/docs/advanced/rebuilding-projections.md
+++ b/docs/docs/advanced/rebuilding-projections.md
@@ -18,3 +18,32 @@ Implementing your own `MessageRepository` and/or `MessageDispatcher` is
 done in a matter of minutes. Keeping this interface simple was a very
 important decision. It means you're able to take **full control** of it
 when (and&nbsp;if) needed.
+
+## Naive replay example
+
+`eventsauce/replay-consumer` is the most naive implementation of a rebuild class. 
+This can be used as inspiration or a starting point for your own implementation that fits your use-case.
+
+The replay consists of 2 steps: 
+1. Drop the current state of your projections. 
+2. Fetch events from the repository, and apply them to the consumers
+
+Some **important** considerations when using the naive way of rebuilding state:
+
+1. During a rebuild, your projection will display old, incorrect data. 
+Your projections will be correct again after the rebuild has finished. 
+2. Recording new events during the rebuild will result in:
+   1. The new event being handled twice
+   2. The events being handled in an incorrect order
+
+Because of the above points, it's recommended to prevent users from using your application during a rebuild.
+
+There are methods to rebuild a projection while keeping the application up. 
+
+A common pattern is to create a rebuild in the background, to a copy of your live projection. 
+When all events are applied to the rebuild, hot-swap the new projection for the old one. 
+
+Another pattern is to introduce some logic in the Consumers. 
+For example, a handler could keep track of the last event it applied for a specific aggregate ID. 
+When it receives an event for the aggregate, it fetches all missing events from the MessageRepository, and applies them in the right order.
+Triggering a replay for a certain aggregate can now be done by calling a specific replay method on the consumer.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,4 +6,5 @@ parameters:
         - %rootDir%/../../../src/CodeGeneration/Fixtures/*
         - %rootDir%/../../../src/LibraryConsumptionTests/*
         - *Test.php
+        - %rootDir%/../../../src/Snapshotting/Tests/LightSwitch.php
     checkMissingIterableValueType: false

--- a/src/ReplayConsumer/.gitattributes
+++ b/src/ReplayConsumer/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+
+.gitattributes export-ignore
+**/*Test.php export-ignore

--- a/src/ReplayConsumer/MessageDispatcherWithBeforeReplay.php
+++ b/src/ReplayConsumer/MessageDispatcherWithBeforeReplay.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace EventSauce\EventSourcing\ReplayConsumer;
+
+use EventSauce\EventSourcing\MessageDispatcher;
+
+interface MessageDispatcherWithBeforeReplay extends MessageDispatcher
+{
+    public function beforeReplay(): void;
+}

--- a/src/ReplayConsumer/MessageDispatcherWithBeforeReplay.php
+++ b/src/ReplayConsumer/MessageDispatcherWithBeforeReplay.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing\ReplayConsumer;
 
 use EventSauce\EventSourcing\MessageDispatcher;

--- a/src/ReplayConsumer/ReplayMessageDispatcher.php
+++ b/src/ReplayConsumer/ReplayMessageDispatcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing\ReplayConsumer;
 
 use EventSauce\EventSourcing\Message;

--- a/src/ReplayConsumer/ReplayMessageDispatcher.php
+++ b/src/ReplayConsumer/ReplayMessageDispatcher.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace EventSauce\EventSourcing\ReplayConsumer;
 
 use EventSauce\EventSourcing\Message;
-use EventSauce\EventSourcing\MessageConsumer;
 use EventSauce\EventSourcing\MessageDispatcher;
 
 class ReplayMessageDispatcher implements MessageDispatcherWithBeforeReplay
 {
     /**
-     * @var list<MessageConsumer>
+     * @var list<ReplayableMessageConsumer>
      */
     private array $consumers;
 

--- a/src/ReplayConsumer/ReplayMessageDispatcher.php
+++ b/src/ReplayConsumer/ReplayMessageDispatcher.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace EventSauce\EventSourcing\ReplayConsumer;
+
+use EventSauce\EventSourcing\Message;
+use EventSauce\EventSourcing\MessageConsumer;
+use EventSauce\EventSourcing\MessageDispatcher;
+
+class ReplayMessageDispatcher implements MessageDispatcherWithBeforeReplay
+{
+    /**
+     * @var list<MessageConsumer>
+     */
+    private array $consumers;
+
+    public function __construct(protected MessageDispatcher $dispatcher, ReplayableMessageConsumer ...$consumers)
+    {
+        $this->consumers = $consumers;
+    }
+
+    public function beforeReplay(): void
+    {
+        foreach ($this->consumers as $consumer) {
+            $consumer->beforeReplay();
+        }
+    }
+
+    public function dispatch(Message ...$messages): void
+    {
+        $this->dispatcher->dispatch(...$messages);
+    }
+}

--- a/src/ReplayConsumer/ReplayMessageDispatcherTest.php
+++ b/src/ReplayConsumer/ReplayMessageDispatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing\ReplayConsumer;
 
 use EventSauce\EventSourcing\ReplayConsumer\TestHelpers\TestReplayableMessageConsumer;
@@ -9,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 class ReplayMessageDispatcherTest extends TestCase
 {
     /** @test */
-    public function it_calls_before_replay_on_message_handler()
+    public function it_calls_before_replay_on_message_handler(): void
     {
         $consumer = new TestReplayableMessageConsumer(1);
         $dispatcher = new ReplayMessageDispatcher(

--- a/src/ReplayConsumer/ReplayMessageDispatcherTest.php
+++ b/src/ReplayConsumer/ReplayMessageDispatcherTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace EventSauce\EventSourcing\ReplayConsumer;
+
+use EventSauce\EventSourcing\ReplayConsumer\TestHelpers\TestReplayableMessageConsumer;
+use EventSauce\EventSourcing\SynchronousMessageDispatcher;
+use PHPUnit\Framework\TestCase;
+
+class ReplayMessageDispatcherTest extends TestCase
+{
+    /** @test */
+    public function it_calls_before_replay_on_message_handler()
+    {
+        $consumer = new TestReplayableMessageConsumer(1);
+        $dispatcher = new ReplayMessageDispatcher(
+            new SynchronousMessageDispatcher(),
+            $consumer
+        );
+
+        $dispatcher->beforeReplay();
+        $this->assertTrue($consumer->beforeReplayIsCalled());
+    }
+}

--- a/src/ReplayConsumer/ReplayMessageRepository.php
+++ b/src/ReplayConsumer/ReplayMessageRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace EventSauce\EventSourcing\ReplayConsumer;
+
+use EventSauce\EventSourcing\Message;
+use EventSauce\EventSourcing\UnableToRetrieveMessages;
+
+use Generator;
+
+interface ReplayMessageRepository
+{
+    /**
+     * @return Generator<Message>
+     * Return of the generator is the offset to use for the next page.
+     * @throws UnableToRetrieveMessages
+     */
+    public function retrieveForReplayFromOffset(int $offset = 0, int $pageSize = 1000): Generator;
+
+    public function hasMessagesAfterOffset(int $offset): bool;
+}

--- a/src/ReplayConsumer/ReplayMessageRepository.php
+++ b/src/ReplayConsumer/ReplayMessageRepository.php
@@ -1,17 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing\ReplayConsumer;
 
 use EventSauce\EventSourcing\Message;
 use EventSauce\EventSourcing\UnableToRetrieveMessages;
-
 use Generator;
 
 interface ReplayMessageRepository
 {
     /**
-     * @return Generator<Message>
-     * Return of the generator is the offset to use for the next page.
+     * @return generator<Message>
+     *                            Return of the generator is the offset to use for the next page
+     *
      * @throws UnableToRetrieveMessages
      */
     public function retrieveForReplayFromOffset(int $offset = 0, int $pageSize = 1000): Generator;

--- a/src/ReplayConsumer/ReplayService.php
+++ b/src/ReplayConsumer/ReplayService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing\ReplayConsumer;
 
 use EventSauce\EventSourcing\MessageDispatcher;
@@ -10,18 +12,17 @@ class ReplayService
         protected ReplayMessageRepository $messageRepository,
         protected MessageDispatcher $dispatcher,
         protected $pageSize = 1000,
-    )
-    {
+    ) {
     }
 
-    public function replay()
+    public function replay(): void
     {
         if ($this->dispatcher instanceof MessageDispatcherWithBeforeReplay) {
             $this->dispatcher->beforeReplay();
         }
 
         $offset = 0;
-        while ($this->messageRepository->hasMessagesAfterOffset($offset)){
+        while ($this->messageRepository->hasMessagesAfterOffset($offset)) {
             $messages = $this->messageRepository->retrieveForReplayFromOffset($offset, $this->pageSize);
             $this->dispatcher->dispatch(...$messages);
             $offset = $messages->getReturn();

--- a/src/ReplayConsumer/ReplayService.php
+++ b/src/ReplayConsumer/ReplayService.php
@@ -11,7 +11,7 @@ class ReplayService
     public function __construct(
         protected ReplayMessageRepository $messageRepository,
         protected MessageDispatcher $dispatcher,
-        protected $pageSize = 1000,
+        protected int $pageSize = 1000,
     ) {
     }
 

--- a/src/ReplayConsumer/ReplayService.php
+++ b/src/ReplayConsumer/ReplayService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace EventSauce\EventSourcing\ReplayConsumer;
+
+use EventSauce\EventSourcing\MessageDispatcher;
+
+class ReplayService
+{
+    public function __construct(
+        protected ReplayMessageRepository $messageRepository,
+        protected MessageDispatcher $dispatcher,
+        protected $pageSize = 1000,
+    )
+    {
+    }
+
+    public function replay()
+    {
+        if ($this->dispatcher instanceof MessageDispatcherWithBeforeReplay) {
+            $this->dispatcher->beforeReplay();
+        }
+
+        $offset = 0;
+        while ($this->messageRepository->hasMessagesAfterOffset($offset)){
+            $messages = $this->messageRepository->retrieveForReplayFromOffset($offset, $this->pageSize);
+            $this->dispatcher->dispatch(...$messages);
+            $offset = $messages->getReturn();
+        }
+    }
+}

--- a/src/ReplayConsumer/ReplayServiceTest.php
+++ b/src/ReplayConsumer/ReplayServiceTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace EventSauce\EventSourcing\ReplayConsumer;
+
+use EventSauce\EventSourcing\DummyAggregateRootId;
+use EventSauce\EventSourcing\EventStub;
+use EventSauce\EventSourcing\Header;
+use EventSauce\EventSourcing\InMemoryMessageRepository;
+use EventSauce\EventSourcing\Message;
+use EventSauce\EventSourcing\ReplayConsumer\TestHelpers\InMemoryReplayMessageRepository;
+use EventSauce\EventSourcing\ReplayConsumer\TestHelpers\TestReplayableMessageConsumer;
+use EventSauce\EventSourcing\SynchronousMessageDispatcher;
+use PHPUnit\Framework\TestCase;
+
+class ReplayServiceTest extends TestCase
+{
+    /** @test */
+    public function it_replays_events_to_the_configured_consumers()
+    {
+        $messageRepository = new InMemoryReplayMessageRepository();
+        $messageRepository->persist(...array_map(
+            fn($number) => new Message(EventStub::create($number)),
+            range(1, 100))
+        );
+
+        $consumer = new TestReplayableMessageConsumer(101);
+        $replayService = new ReplayService(
+            $messageRepository,
+            new SynchronousMessageDispatcher(
+                $consumer,
+            ),
+            10
+        );
+
+        $replayService->replay();
+        $this->assertEquals(100, $consumer->numberOfMessagesProcessed());
+    }
+
+    /** @test */
+    public function it_calls_before_replay_when_message_dispatcher_supports_it()
+    {
+        $messageRepository = new InMemoryReplayMessageRepository();
+        $messageRepository->persist(...array_map(
+                fn($number) => new Message(EventStub::create($number)),
+                range(1, 100))
+        );
+
+        $consumer = new TestReplayableMessageConsumer(101);
+        $replayService = new ReplayService(
+            $messageRepository,
+            new ReplayMessageDispatcher(
+                new SynchronousMessageDispatcher(
+                    $consumer,
+                ),
+                $consumer,
+            ),
+            10
+        );
+
+        $replayService->replay();
+        $this->assertEquals(100, $consumer->numberOfMessagesProcessed());
+        $this->assertTrue($consumer->beforeReplayIsCalled());
+    }
+}

--- a/src/ReplayConsumer/ReplayServiceTest.php
+++ b/src/ReplayConsumer/ReplayServiceTest.php
@@ -1,11 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing\ReplayConsumer;
 
-use EventSauce\EventSourcing\DummyAggregateRootId;
 use EventSauce\EventSourcing\EventStub;
-use EventSauce\EventSourcing\Header;
-use EventSauce\EventSourcing\InMemoryMessageRepository;
 use EventSauce\EventSourcing\Message;
 use EventSauce\EventSourcing\ReplayConsumer\TestHelpers\InMemoryReplayMessageRepository;
 use EventSauce\EventSourcing\ReplayConsumer\TestHelpers\TestReplayableMessageConsumer;
@@ -15,11 +14,11 @@ use PHPUnit\Framework\TestCase;
 class ReplayServiceTest extends TestCase
 {
     /** @test */
-    public function it_replays_events_to_the_configured_consumers()
+    public function it_replays_events_to_the_configured_consumers(): void
     {
         $messageRepository = new InMemoryReplayMessageRepository();
         $messageRepository->persist(...array_map(
-            fn($number) => new Message(EventStub::create($number)),
+            fn ($number) => new Message(EventStub::create($number)),
             range(1, 100))
         );
 
@@ -37,11 +36,11 @@ class ReplayServiceTest extends TestCase
     }
 
     /** @test */
-    public function it_calls_before_replay_when_message_dispatcher_supports_it()
+    public function it_calls_before_replay_when_message_dispatcher_supports_it(): void
     {
         $messageRepository = new InMemoryReplayMessageRepository();
         $messageRepository->persist(...array_map(
-                fn($number) => new Message(EventStub::create($number)),
+                fn ($number) => new Message(EventStub::create($number)),
                 range(1, 100))
         );
 

--- a/src/ReplayConsumer/ReplayServiceTest.php
+++ b/src/ReplayConsumer/ReplayServiceTest.php
@@ -18,7 +18,7 @@ class ReplayServiceTest extends TestCase
     {
         $messageRepository = new InMemoryReplayMessageRepository();
         $messageRepository->persist(...array_map(
-            fn ($number) => new Message(EventStub::create($number)),
+            fn ($number) => new Message(EventStub::create((string) $number)),
             range(1, 100))
         );
 
@@ -40,7 +40,7 @@ class ReplayServiceTest extends TestCase
     {
         $messageRepository = new InMemoryReplayMessageRepository();
         $messageRepository->persist(...array_map(
-                fn ($number) => new Message(EventStub::create($number)),
+                fn ($number) => new Message(EventStub::create((string) $number)),
                 range(1, 100))
         );
 

--- a/src/ReplayConsumer/ReplayableMessageConsumer.php
+++ b/src/ReplayConsumer/ReplayableMessageConsumer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace EventSauce\EventSourcing\ReplayConsumer;
+
+use EventSauce\EventSourcing\MessageConsumer;
+
+interface ReplayableMessageConsumer extends MessageConsumer
+{
+    public function beforeReplay(): void;
+}

--- a/src/ReplayConsumer/ReplayableMessageConsumer.php
+++ b/src/ReplayConsumer/ReplayableMessageConsumer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing\ReplayConsumer;
 
 use EventSauce\EventSourcing\MessageConsumer;

--- a/src/ReplayConsumer/TestHelpers/InMemoryReplayMessageRepository.php
+++ b/src/ReplayConsumer/TestHelpers/InMemoryReplayMessageRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing\ReplayConsumer\TestHelpers;
 
 use EventSauce\EventSourcing\AggregateRootId;
@@ -7,7 +9,6 @@ use EventSauce\EventSourcing\Header;
 use EventSauce\EventSourcing\Message;
 use EventSauce\EventSourcing\MessageRepository;
 use EventSauce\EventSourcing\ReplayConsumer\ReplayMessageRepository;
-use EventSauce\EventSourcing\UnableToRetrieveMessages;
 use Generator;
 
 class InMemoryReplayMessageRepository implements ReplayMessageRepository, MessageRepository

--- a/src/ReplayConsumer/TestHelpers/InMemoryReplayMessageRepository.php
+++ b/src/ReplayConsumer/TestHelpers/InMemoryReplayMessageRepository.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace EventSauce\EventSourcing\ReplayConsumer\TestHelpers;
+
+use EventSauce\EventSourcing\AggregateRootId;
+use EventSauce\EventSourcing\Header;
+use EventSauce\EventSourcing\Message;
+use EventSauce\EventSourcing\MessageRepository;
+use EventSauce\EventSourcing\ReplayConsumer\ReplayMessageRepository;
+use EventSauce\EventSourcing\UnableToRetrieveMessages;
+use Generator;
+
+class InMemoryReplayMessageRepository implements ReplayMessageRepository, MessageRepository
+{
+    /**
+     * @var Message[]
+     */
+    private array $messages = [];
+
+    /**
+     * @var object[]
+     */
+    private array $lastCommit = [];
+
+    /**
+     * @return object[]
+     */
+    public function lastCommit(): array
+    {
+        return $this->lastCommit;
+    }
+
+    public function purgeLastCommit(): void
+    {
+        $this->lastCommit = [];
+    }
+
+    public function persist(Message ...$messages): void
+    {
+        $this->lastCommit = [];
+
+        /** @var Message $message */
+        foreach ($messages as $message) {
+            $this->messages[] = $message;
+            $this->lastCommit[] = $message->event();
+        }
+    }
+
+    public function retrieveAll(AggregateRootId $id): Generator
+    {
+        $lastMessage = null;
+
+        foreach ($this->messages as $message) {
+            if ($id->toString() === $message->aggregateRootId()?->toString()) {
+                yield $message;
+                $lastMessage = $message;
+            }
+        }
+
+        return $lastMessage instanceof Message ? $lastMessage->aggregateVersion() : 0;
+    }
+
+    public function retrieveAllAfterVersion(AggregateRootId $id, int $aggregateRootVersion): Generator
+    {
+        $lastMessage = null;
+
+        foreach ($this->messages as $message) {
+            if ($id->toString() === $message->aggregateRootId()?->toString()
+                && $message->header(Header::AGGREGATE_ROOT_VERSION) > $aggregateRootVersion) {
+                yield $message;
+                $lastMessage = $message;
+            }
+        }
+
+        return $lastMessage instanceof Message ? $lastMessage->aggregateVersion() : 0;
+    }
+
+    public function retrieveForReplayFromOffset(int $offset = 0, int $pageSize = 1000): Generator
+    {
+        foreach (array_slice($this->messages, $offset, $pageSize) as $message) {
+            yield $message;
+        }
+
+        return $offset + $pageSize;
+    }
+
+    public function hasMessagesAfterOffset(int $offset): bool
+    {
+        return count(array_slice($this->messages, $offset, 1)) > 0;
+    }
+}

--- a/src/ReplayConsumer/TestHelpers/TestReplayableMessageConsumer.php
+++ b/src/ReplayConsumer/TestHelpers/TestReplayableMessageConsumer.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace EventSauce\EventSourcing\ReplayConsumer\TestHelpers;
+
+use EventSauce\EventSourcing\Message;
+use EventSauce\EventSourcing\ReplayConsumer\ReplayableMessageConsumer;
+use LogicException;
+
+class TestReplayableMessageConsumer implements ReplayableMessageConsumer
+{
+    private int $failAfterNumberOfMessages;
+    private int $numberOfMessagesProcessed = 0;
+    private bool $beforeReplayCalled = false;
+
+    public function __construct(int $failAfterNumberOfMessages)
+    {
+        $this->failAfterNumberOfMessages = $failAfterNumberOfMessages;
+    }
+
+    public function handle(Message $message): void
+    {
+        if (++$this->numberOfMessagesProcessed === $this->failAfterNumberOfMessages) {
+            throw new LogicException('Too many messages');
+        }
+    }
+
+    public function numberOfMessagesProcessed(): int
+    {
+        return $this->numberOfMessagesProcessed;
+    }
+
+    public function beforeReplay(): void
+    {
+        $this->beforeReplayCalled = true;
+    }
+
+    public function beforeReplayIsCalled(): bool
+    {
+        return $this->beforeReplayCalled;
+    }
+}

--- a/src/ReplayConsumer/TestHelpers/TestReplayableMessageConsumer.php
+++ b/src/ReplayConsumer/TestHelpers/TestReplayableMessageConsumer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\EventSourcing\ReplayConsumer\TestHelpers;
 
 use EventSauce\EventSourcing\Message;

--- a/src/ReplayConsumer/composer.json
+++ b/src/ReplayConsumer/composer.json
@@ -1,0 +1,25 @@
+{
+  "name": "eventsauce/replay-consumer",
+  "type": "library",
+  "description": "Naive consumer replay implementation for EventSauce",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Frank de Jonge",
+      "email": "info@frenky.net"
+    },
+    {
+      "name": "Robert Baelde",
+      "email": "robert@baelde.nl"
+    }
+  ],
+  "require": {
+    "php": "^8.0",
+    "eventsauce/eventsauce": "^1.0",
+  },
+  "autoload": {
+    "psr-4": {
+      "EventSauce\\EventSourcing\\ReplayConsumer\\": "./"
+    }
+  }
+}

--- a/src/Snapshotting/SnapshottingBehaviour.php
+++ b/src/Snapshotting/SnapshottingBehaviour.php
@@ -31,7 +31,7 @@ trait SnapshottingBehaviour
     public static function reconstituteFromSnapshotAndEvents(Snapshot $snapshot, Generator $events): static
     {
         $id = $snapshot->aggregateRootId();
-        /** @var static&AggregateRoot $aggregateRoot */
+        /** @var static|AggregateRoot $aggregateRoot */
         $aggregateRoot = static::reconstituteFromSnapshotState($id, $snapshot->state());
         $aggregateRoot->aggregateRootVersion = $snapshot->aggregateRootVersion();
 


### PR DESCRIPTION
Hi Frank,

Let me start this (controversial) PR by saying that I totally agree with the statement about rebuilds you make in the documentation. 

I noticed a few times now, that it might scare people away while choosing an EventSourcing package. 
Arguments like "Package X is better because it gives you replays out of the box" are easy to make for organisations getting started with EventSourcing. The perspective of "building your own rebuild mechanism" seems scary, and like a lot of work.

The idea behind this "example" rebuild implementation is to show people how easy it is to have a naive implementation (the implementation packages like https://github.com/spatie/laravel-event-sourcing provide). 

I've updated the docs with why this naive implementation might not be a good fit in most situations and a short pointer to more robust rebuild strategies. 

Curious if you noticed the same questions/discussions on this part of the package? And if you agree an example implementation might make the "Implementing your own is done in a matter of minutes"  more concrete?

Although this adds a few lines of code to the package, I made sure that there were no changes needed in the "core". And all code lives in a separate directory that can be split into its own repository. 

Cheers ✌️ 🚀 

Todo before merge: 

- [ ] create read-only repository and test if split works 
