### PR TITLE
Explicit parse to string to make phpstan happy

### DIFF
--- a/src/ArrayLookupClassNameInflector.php
+++ b/src/ArrayLookupClassNameInflector.php
@@ -17,7 +17,7 @@ class ArrayLookupClassNameInflector implements ClassNameInflector
             throw new \Exception("Configure {$className} in event type lookup");
         }
 
-        return $type;
+        return (string) $type;
     }
 
     public function typeToClassName(string $eventType): string


### PR DESCRIPTION
I noticed that phpstan wasn't happy with my last PR (https://github.com/EventSaucePHP/EventSauce/pull/1520) 

This PR fixes that by explicitly parsing the type to string. 