### PR TITLE
Encode to/from json to help testing enums in events

### DIFF
--- a/src/TestUtilities/MessageConsumerThatSerializesMessages.php
+++ b/src/TestUtilities/MessageConsumerThatSerializesMessages.php
@@ -25,7 +25,14 @@ class MessageConsumerThatSerializesMessages implements MessageConsumer
     public function handle(Message $message): void
     {
         $payload = $this->serializer->serializeMessage($message);
-        $deserializedMessage = $this->serializer->unserializePayload($payload);
+        $payloadAsString = json_encode($payload);
+        if ($payloadAsString === false) {
+            TestCase::fail('Payload could not be serialized');
+        }
+
+        $deserializedMessage = $this->serializer->unserializePayload(
+            json_decode($payloadAsString, true)
+        );
         TestCase::assertEquals($message->event(), $deserializedMessage->event());
     }
 }


### PR DESCRIPTION
To ensure there are no more PHP objects in the payload, we encode to and from JSON.

This is helpful when putting Enum objects in events.

Eg when we have an enum object: 

```php
enum Option: string
{
    case a = 'a';
    case b = 'b';
}
```

And an event containing this enum: 

```php

class OptionSelected implements SerializablePayload
{
    public function __construct(public readonly Option $option)
    {
    }

    public function toPayload(): array
    {
        return [
            'option' => $this->option,
        ];
    }

    public static function fromPayload(array $payload): SerializablePayload
    {
        return new self(
            Option::tryFrom($payload['option'])
        );
    }
```

When working with a database implementation, it works. Because when the enum is parsed to JSON, its value is stored. 

When serializing in the `MessageConsumerThatSerializesMessages`, the contents aren't parsed. Resulting in `tryFrom` being called with the enum object. 

In the end, I think its best to bring this test class closer to the working of a "real world" implementation