### PR TITLE
Add Shopping cart example to consumption tests

### DIFF
--- a/src/LibraryConsumptionTests/ShoppingCartExample/CartItems.php
+++ b/src/LibraryConsumptionTests/ShoppingCartExample/CartItems.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample;
+
+use EventSauce\EventSourcing\AggregateAppliesKnownEvents;
+use EventSauce\EventSourcing\EventRecorder;
+use EventSauce\EventSourcing\EventSourcedAggregate;
+use EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Events\ProductAddedToCart;
+use EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Exceptions\SorryCantAddProduct;
+
+class CartItems implements EventSourcedAggregate
+{
+    use AggregateAppliesKnownEvents;
+
+    private array $items = [];
+
+    public function __construct(private EventRecorder $eventRecorder)
+    {
+    }
+
+    public function add(ProductId $productId, int $currentPriceInCents): void
+    {
+        if (array_key_exists($productId->toString(), $this->items)) {
+            if ($this->items[$productId->toString()]['price'] !== $currentPriceInCents) {
+                throw SorryCantAddProduct::becauseThePriceHasChanged();
+            }
+        }
+        $this->eventRecorder->recordThat(new ProductAddedToCart($productId, $currentPriceInCents));
+    }
+
+    public function isEmpty(): bool
+    {
+        return count($this->items) === 0;
+    }
+
+    protected function applyProductAddedToCart(ProductAddedToCart $event): void
+    {
+        $productIdAsString = $event->productId->toString();
+        if ( ! array_key_exists($productIdAsString, $this->items)) {
+            $this->items[$productIdAsString] = ['qty' => 0, 'price' => $event->price];
+        }
+        ++$this->items[$productIdAsString]['qty'];
+    }
+}

--- a/src/LibraryConsumptionTests/ShoppingCartExample/CartItemsTest.php
+++ b/src/LibraryConsumptionTests/ShoppingCartExample/CartItemsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample;
+
+use EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Events\ProductAddedToCart;
+use EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Events\ShoppingCartInitiated;
+use EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Exceptions\SorryCantAddProduct;
+
+class CartItemsTest extends ShoppingCartTestCase
+{
+    /** @test */
+    public function a_item_can_be_added_to_a_cart(): void
+    {
+        $this
+            ->given(
+                new ShoppingCartInitiated(),
+            )
+            ->when(function (ShoppingCart $cart): void {
+                $cart->addProduct(new ProductId('garlic sauce'), 250);
+            })
+            ->then(
+                new ProductAddedToCart(new ProductId('garlic sauce'), 250)
+            );
+    }
+
+    /** @test */
+    public function same_item_can_be_added_multiple_times(): void
+    {
+        $this
+            ->given(
+                new ShoppingCartInitiated(),
+                new ProductAddedToCart(new ProductId('garlic sauce'), 250),
+            )
+            ->when(function (ShoppingCart $cart): void {
+                $cart->addProduct(new ProductId('garlic sauce'), 250);
+            })
+            ->then(
+                new ProductAddedToCart(new ProductId('garlic sauce'), 250)
+            );
+    }
+
+    /** @test */
+    public function when_the_price_of_a_product_changed_the_item_cannot_be_added(): void
+    {
+        $this
+            ->given(
+                new ShoppingCartInitiated(),
+                new ProductAddedToCart(new ProductId('garlic sauce'), 250),
+            )
+            ->when(function (ShoppingCart $cart): void {
+                $cart->addProduct(new ProductId('garlic sauce'), 300);
+            })
+            ->expectToFail(SorryCantAddProduct::becauseThePriceHasChanged())
+            ->thenNothingShouldHaveHappened();
+    }
+}

--- a/src/LibraryConsumptionTests/ShoppingCartExample/Events/CartCheckedOut.php
+++ b/src/LibraryConsumptionTests/ShoppingCartExample/Events/CartCheckedOut.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Events;
+
+use EventSauce\EventSourcing\Serialization\SerializablePayload;
+
+class CartCheckedOut implements SerializablePayload
+{
+
+    public function toPayload(): array
+    {
+        return [];
+    }
+
+    public static function fromPayload(array $payload): self
+    {
+        return new self();
+    }
+}

--- a/src/LibraryConsumptionTests/ShoppingCartExample/Events/ProductAddedToCart.php
+++ b/src/LibraryConsumptionTests/ShoppingCartExample/Events/ProductAddedToCart.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Events;
+
+use EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\ProductId;
+use EventSauce\EventSourcing\Serialization\SerializablePayload;
+
+class ProductAddedToCart implements SerializablePayload
+{
+
+    public function __construct(public ProductId $productId, public int $price)
+    {
+    }
+
+    public function toPayload(): array
+    {
+        return [
+            'productId' => $this->productId->toString(),
+            'price' => $this->price,
+        ];
+    }
+
+    public static function fromPayload(array $payload): self
+    {
+        return new self(
+            ProductId::fromString($payload['productId']),
+            $payload['price']
+        );
+    }
+}

--- a/src/LibraryConsumptionTests/ShoppingCartExample/Events/ShoppingCartInitiated.php
+++ b/src/LibraryConsumptionTests/ShoppingCartExample/Events/ShoppingCartInitiated.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Events;
+
+use EventSauce\EventSourcing\Serialization\SerializablePayload;
+
+class ShoppingCartInitiated implements SerializablePayload
+{
+
+    public function __construct()
+    {
+    }
+
+    public function toPayload(): array
+    {
+        return [];
+    }
+
+    public static function fromPayload(array $payload): SerializablePayload
+    {
+        return new self();
+    }
+}

--- a/src/LibraryConsumptionTests/ShoppingCartExample/Exceptions/SorryCantAddProduct.php
+++ b/src/LibraryConsumptionTests/ShoppingCartExample/Exceptions/SorryCantAddProduct.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Exceptions;
+
+class SorryCantAddProduct extends \Exception
+{
+
+    public static function becauseThePriceHasChanged(): self
+    {
+        return new self();
+    }
+}

--- a/src/LibraryConsumptionTests/ShoppingCartExample/Exceptions/SorryCantCheckout.php
+++ b/src/LibraryConsumptionTests/ShoppingCartExample/Exceptions/SorryCantCheckout.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Exceptions;
+
+class SorryCantCheckout extends \Exception
+{
+
+    public static function becauseThereAreNoProductsInCart(): self
+    {
+        return new self();
+    }
+}

--- a/src/LibraryConsumptionTests/ShoppingCartExample/ProductId.php
+++ b/src/LibraryConsumptionTests/ShoppingCartExample/ProductId.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample;
+
+class ProductId
+{
+    public function __construct(protected string $id)
+    {
+
+    }
+
+    public function toString(): string
+    {
+        return $this->id;
+    }
+
+    public static function fromString(string $id): self
+    {
+        return new self($id);
+    }
+}

--- a/src/LibraryConsumptionTests/ShoppingCartExample/ShoppingCart.php
+++ b/src/LibraryConsumptionTests/ShoppingCartExample/ShoppingCart.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample;
+
+use EventSauce\EventSourcing\AggregateRoot;
+use EventSauce\EventSourcing\AggregateRootWithAggregates;
+use EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Events\CartCheckedOut;
+use EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Events\ShoppingCartInitiated;
+use EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Exceptions\SorryCantCheckout;
+
+class ShoppingCart implements AggregateRoot
+{
+    use AggregateRootWithAggregates;
+
+    private CartItems $cartItems;
+
+    public static function initiate(ShoppingCartId $id): static
+    {
+        $shoppingCart = new static($id);
+        $shoppingCart->recordThat(new ShoppingCartInitiated());
+
+        return $shoppingCart;
+    }
+
+    public function addProduct(ProductId $productId, int $currentPriceInCents): void
+    {
+        $this->cartItems->add($productId, $currentPriceInCents);
+    }
+
+    public function checkout(): void
+    {
+        if ($this->cartItems->isEmpty()) {
+            throw SorryCantCheckout::becauseThereAreNoProductsInCart();
+        }
+        $this->recordThat(new CartCheckedOut());
+    }
+
+    protected function applyShoppingCartInitiated(ShoppingCartInitiated $event): void
+    {
+        $this->bootCartItemsAggregate();
+    }
+
+    private function bootCartItemsAggregate(): void
+    {
+        $this->cartItems = new CartItems($this->eventRecorder());
+        $this->registerAggregate($this->cartItems);
+    }
+}

--- a/src/LibraryConsumptionTests/ShoppingCartExample/ShoppingCartId.php
+++ b/src/LibraryConsumptionTests/ShoppingCartExample/ShoppingCartId.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample;
+
+use EventSauce\EventSourcing\AggregateRootId;
+
+class ShoppingCartId implements AggregateRootId
+{
+
+    private function __construct(private string $aggregateRootId)
+    {
+    }
+
+    public function toString(): string
+    {
+        return $this->aggregateRootId;
+    }
+
+    public static function fromString(string $aggregateRootId): self
+    {
+        return new self($aggregateRootId);
+    }
+
+    public static function create(): self
+    {
+        return self::fromString(bin2hex(random_bytes(25)));
+    }
+}

--- a/src/LibraryConsumptionTests/ShoppingCartExample/ShoppingCartLifecycleTest.php
+++ b/src/LibraryConsumptionTests/ShoppingCartExample/ShoppingCartLifecycleTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample;
+
+use EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Events\CartCheckedOut;
+use EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Events\ProductAddedToCart;
+use EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Events\ShoppingCartInitiated;
+use EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Exceptions\SorryCantCheckout;
+
+class ShoppingCartLifecycleTest extends ShoppingCartTestCase
+{
+    /** @test */
+    public function a_shopping_cart_can_be_initiated(): void
+    {
+        $cart = ShoppingCart::initiate($this->aggregateRootId());
+        $this->repository->persist($cart);
+
+        $this->then(
+            new ShoppingCartInitiated()
+        );
+    }
+
+    /** @test */
+    public function shopping_cart_cannot_be_checked_out_when_there_are_no_items_in_it(): void
+    {
+        $this
+            ->given(new ShoppingCartInitiated())
+            ->when(function (ShoppingCart $cart): void {
+                $cart->checkout();
+            })
+            ->expectToFail(SorryCantCheckout::becauseThereAreNoProductsInCart());
+    }
+
+    /** @test */
+    public function a_shopping_cart_can_checkout_when_there_are_products_in_the_cart(): void
+    {
+        $this
+            ->given(
+                new ShoppingCartInitiated(),
+                new ProductAddedToCart(ProductId::fromString('garlic-sauce'), 250),
+                new ProductAddedToCart(ProductId::fromString('garlic-sauce'), 250)
+            )
+            ->when(function (ShoppingCart $cart): void {
+                $cart->checkout();
+            })
+            ->then(
+                new CartCheckedOut()
+            );
+    }
+}

--- a/src/LibraryConsumptionTests/ShoppingCartExample/ShoppingCartTestCase.php
+++ b/src/LibraryConsumptionTests/ShoppingCartExample/ShoppingCartTestCase.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample;
+
+use EventSauce\EventSourcing\AggregateRootId;
+use EventSauce\EventSourcing\TestUtilities\AggregateRootTestCase;
+
+class ShoppingCartTestCase extends AggregateRootTestCase
+{
+    protected function newAggregateRootId(): AggregateRootId
+    {
+        return ShoppingCartId::create();
+    }
+
+    protected function aggregateRootClassName(): string
+    {
+        return ShoppingCart::class;
+    }
+
+    public function handle(\Closure $closure): void
+    {
+        /** @var ShoppingCart $aggregate */
+        $aggregate = $this->repository->retrieve($this->aggregateRootId);
+        $closure($aggregate);
+        $this->repository->persist($aggregate);
+    }
+}


### PR DESCRIPTION
I think it would be great to have a bit more "real world" example in the consumption tests. This could be used to test how certain aspects of the package work together, but more important: it shows how the package could be used.

I think it would be great to end up with one example we could use throughout the whole documentation. When maintainers agree with this idea, I'm keen on adding more complex logic, and stuff like consumers. 

It could be, that in the end, this is outside of the scope of the package. In that case, I'm more than happy to extract it to a separate repo. 