### PR TITLE
Extract default AggregateRoot implementation into its own trait.

### DIFF
--- a/src/AggregateRootBehaviour.php
+++ b/src/AggregateRootBehaviour.php
@@ -12,61 +12,18 @@ use Generator;
 trait AggregateRootBehaviour
 {
     use AggregateAlwaysAppliesEvents;
-
-    private AggregateRootId $aggregateRootId;
-    private int $aggregateRootVersion = 0;
-    /** @var list<object> */
-    private array $recordedEvents = [];
+    use DefaultAggregateRootImplementation;
 
     private function __construct(AggregateRootId $aggregateRootId)
     {
         $this->aggregateRootId = $aggregateRootId;
     }
 
-    public function aggregateRootId(): AggregateRootId
-    {
-        return $this->aggregateRootId;
-    }
-
     /**
-     * @see AggregateRoot::aggregateRootVersion
+     * @see DefaultAggregateRootImplementation::instantiateForReconstitution()
      */
-    public function aggregateRootVersion(): int
+    protected static function instantiateForReconstitution(AggregateRootId $aggregateRootId): static
     {
-        return $this->aggregateRootVersion;
-    }
-
-    protected function recordThat(object $event): void
-    {
-        $this->apply($event);
-        $this->recordedEvents[] = $event;
-    }
-
-    /**
-     * @return object[]
-     */
-    public function releaseEvents(): array
-    {
-        $releasedEvents = $this->recordedEvents;
-        $this->recordedEvents = [];
-
-        return $releasedEvents;
-    }
-
-    /**
-     * @see AggregateRoot::reconstituteFromEvents
-     */
-    public static function reconstituteFromEvents(AggregateRootId $aggregateRootId, Generator $events): static
-    {
-        $aggregateRoot = new static($aggregateRootId);
-
-        /** @var object $event */
-        foreach ($events as $event) {
-            $aggregateRoot->apply($event);
-        }
-
-        $aggregateRoot->aggregateRootVersion = $events->getReturn() ?: 0;
-
-        return $aggregateRoot;
+        return new static($aggregateRootId);
     }
 }

--- a/src/DefaultAggregateRootImplementation.php
+++ b/src/DefaultAggregateRootImplementation.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace EventSauce\EventSourcing;
+
+use Generator;
+
+trait DefaultAggregateRootImplementation
+{
+    private AggregateRootId $aggregateRootId;
+    private int $aggregateRootVersion = 0;
+    /** @var list<object> */
+    private array $recordedEvents = [];
+
+    /**
+     * @see AggregateRoot::aggregateRootId
+     */
+    public function aggregateRootId(): AggregateRootId
+    {
+        return $this->aggregateRootId;
+    }
+
+    /**
+     * @see AggregateRoot::aggregateRootVersion
+     */
+    public function aggregateRootVersion(): int
+    {
+        return $this->aggregateRootVersion;
+    }
+
+    protected function recordThat(object $event): void
+    {
+        $this->apply($event);
+        $this->recordedEvents[] = $event;
+    }
+
+    /**
+     * @see AggregateRoot::releaseEvents
+     * @return object[]
+     */
+    public function releaseEvents(): array
+    {
+        $releasedEvents = $this->recordedEvents;
+        $this->recordedEvents = [];
+
+        return $releasedEvents;
+    }
+
+    abstract protected static function instantiateForReconstitution(AggregateRootId $aggregateRootId): static;
+
+    /**
+     * @see AggregateRoot::reconstituteFromEvents
+     */
+    public static function reconstituteFromEvents(AggregateRootId $aggregateRootId, Generator $events): static
+    {
+        $aggregateRoot = static::instantiateForReconstitution($aggregateRootId);
+
+        /** @var object $event */
+        foreach ($events as $event) {
+            $aggregateRoot->apply($event);
+        }
+
+        $aggregateRoot->aggregateRootVersion = $events->getReturn() ?: 0;
+
+        return $aggregateRoot;
+    }
+}


### PR DESCRIPTION
This will allow people to create their own `AggregateRoot` implementation without having to reimplement the underlying business logic. For example, if a model uses a base class, like an Eloquent Model, work needs to be done in the base class's constructor. If we can extract the actual implementation bits from the existing `AggregateRootBehavior`, creating a new behavior that still calls the constructor but still sets the aggregate root ID is trivial.

```php
trait EloquentAggregateRootBehavior
{
    use DefaultAggregateRootImplementation;
    use AggregateAlwaysAppliesEvents;

    public static function instantiateForReconstitution(AggregateRootId $aggregateRootId): static
    {
        $instance = new static(); // model is now initialized as expected...
        $instance->aggregateRootId = $aggregateRootId;

        return $instance;
    }
}
```
