### PR TITLE
ACL organise filters and translators

### DIFF
--- a/docs/docs/advanced/anti-corruption-layer.md
+++ b/docs/docs/advanced/anti-corruption-layer.md
@@ -21,7 +21,7 @@ that implement the `MessageTranslator` interface.
 ```php
 namespace AcmeCorp\SomeDomain;
 
-use EventSauce\EventSourcing\AntiCorruptionLayer\MessageTranslator;
+use EventSauce\EventSourcing\AntiCorruptionLayer\Translators\MessageTranslator;
 use EventSauce\EventSourcing\Message;
 
 class MyMessageTranslator implements MessageTranslator
@@ -37,7 +37,7 @@ If you do not wish to convert the message at all, you can use the _passthrough_ 
 built-in implementation does simply passes on the original message.
 
 ```php
-use EventSauce\EventSourcing\AntiCorruptionLayer\PassthroughMessageTranslator;
+use EventSauce\EventSourcing\AntiCorruptionLayer\Translators\PassthroughMessageTranslator;
 
 $translator = new PassthroughMessageTranslator();
 ```
@@ -50,7 +50,8 @@ that implement the `MessageFilter` interface.
 ```php
 namespace AcmeCorp\SomeDomain;
 
-use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilter;use EventSauce\EventSourcing\Message;
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\MessageFilter;
+use EventSauce\EventSourcing\Message;
 
 class AllowOnlyPublicEvents implements MessageFilter
 {
@@ -69,8 +70,8 @@ The outbound ACL is a message dispatcher decorator that uses filters and a trans
 only relevant messages onto the inner dispatcher.
 
 ```php
-use EventSauce\EventSourcing\AntiCorruptionLayer\AllowAllMessages;
 use EventSauce\EventSourcing\AntiCorruptionLayer\AntiCorruptionMessageDispatcher;
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\AllowAllMessages;
 use EventSauce\EventSourcing\Message;
 use EventSauce\EventSourcing\MessageDispatcher;
 
@@ -93,8 +94,8 @@ The inbound ACL is a message consumer decorator that uses filters and a translat
 only relevant messages onto the inner consumer.
 
 ```php
-use EventSauce\EventSourcing\AntiCorruptionLayer\AllowAllMessages;
 use EventSauce\EventSourcing\AntiCorruptionLayer\AntiCorruptionMessageConsumer;
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\AllowAllMessages;
 use EventSauce\EventSourcing\Message;
 use EventSauce\EventSourcing\MessageConsumer;
 
@@ -120,7 +121,7 @@ A number of message filters are built-in:
 Allows filtering events/payloads by class-names.
 
 ```php
-use EventSauce\EventSourcing\AntiCorruptionLayer\AllowMessagesWithPayloadOfType;
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\AllowMessagesWithPayloadOfType;
 
 $filter = new AllowMessagesWithPayloadOfType(
     PublicEvent::class,
@@ -133,7 +134,7 @@ $filter = new AllowMessagesWithPayloadOfType(
 Allows all messages to pass through
 
 ```php
-use EventSauce\EventSourcing\AntiCorruptionLayer\AllowAllMessages;
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\AllowAllMessages;
 
 $filter = new AllowAllMessages();
 ```
@@ -143,7 +144,7 @@ $filter = new AllowAllMessages();
 Allows no messages to pass through
 
 ```php
-use EventSauce\EventSourcing\AntiCorruptionLayer\NeverAllowMessages;
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\NeverAllowMessages;
 
 $filter = new NeverAllowMessages();
 ```
@@ -153,7 +154,7 @@ $filter = new NeverAllowMessages();
 Only passes on messages if all inner filters allows the message to pass through.
 
 ```php
-use EventSauce\EventSourcing\AntiCorruptionLayer\MatchAllMessageFilters;
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\MatchAllMessageFilters;
 
 $filter = new MatchAllMessageFilters(
     new MyFilter(),
@@ -166,7 +167,7 @@ $filter = new MatchAllMessageFilters(
 Passes on messages if _any_ of the inner filters allows the message to pass through.
 
 ```php
-use EventSauce\EventSourcing\AntiCorruptionLayer\MatchAnyMessageFilter;
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\MatchAnyMessageFilter;
 
 $filter = new MatchAnyMessageFilter(
     new MyFilter(),
@@ -184,7 +185,7 @@ Passes on messages unmodified.
 
 ```php
 
-use EventSauce\EventSourcing\AntiCorruptionLayer\PassthroughMessageTranslator;
+use EventSauce\EventSourcing\AntiCorruptionLayer\Translators\PassthroughMessageTranslator;
 
 $translator = new PassthroughMessageTranslator();
 ```
@@ -195,7 +196,7 @@ Uses a specific translator per payload class-name.
 
 ```php
 
-use EventSauce\EventSourcing\AntiCorruptionLayer\MessageTranslatorPerPayloadType;
+use EventSauce\EventSourcing\AntiCorruptionLayer\Translators\MessageTranslatorPerPayloadType;
 
 $translator = new MessageTranslatorPerPayloadType([
     SomePayload::class => new SomePayloadTranslator(),
@@ -209,7 +210,7 @@ Uses a multiple translators, passes the message through each
 
 ```php
 
-use EventSauce\EventSourcing\AntiCorruptionLayer\MessageTranslatorChain;
+use EventSauce\EventSourcing\AntiCorruptionLayer\Translators\MessageTranslatorChain;
 
 $translator = new MessageTranslatorChain(
     new SomePayloadTranslator(), // first pass

--- a/src/AntiCorruptionLayer/AntiCorruptionMessageConsumer.php
+++ b/src/AntiCorruptionLayer/AntiCorruptionMessageConsumer.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace EventSauce\EventSourcing\AntiCorruptionLayer;
 
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\AllowAllMessages;
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\MessageFilter;
+use EventSauce\EventSourcing\AntiCorruptionLayer\Translators\MessageTranslator;
 use EventSauce\EventSourcing\Message;
 use EventSauce\EventSourcing\MessageConsumer;
 

--- a/src/AntiCorruptionLayer/AntiCorruptionMessageConsumerTest.php
+++ b/src/AntiCorruptionLayer/AntiCorruptionMessageConsumerTest.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace EventSauce\EventSourcing\AntiCorruptionLayer;
 
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\AllowAllMessages;
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\AllowMessagesWithPayloadOfType;
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\MessageFilter;
+use EventSauce\EventSourcing\AntiCorruptionLayer\Translators\MessageTranslator;
+use EventSauce\EventSourcing\AntiCorruptionLayer\Translators\PassthroughMessageTranslator;
 use EventSauce\EventSourcing\CollectingMessageConsumer;
 use EventSauce\EventSourcing\Message;
 use PHPStan\Testing\TestCase;
-
 use function array_map;
 
 class AntiCorruptionMessageConsumerTest extends TestCase

--- a/src/AntiCorruptionLayer/AntiCorruptionMessageDispatcher.php
+++ b/src/AntiCorruptionLayer/AntiCorruptionMessageDispatcher.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace EventSauce\EventSourcing\AntiCorruptionLayer;
 
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\AllowAllMessages;
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\MessageFilter;
+use EventSauce\EventSourcing\AntiCorruptionLayer\Translators\MessageTranslator;
 use EventSauce\EventSourcing\Message;
 use EventSauce\EventSourcing\MessageDispatcher;
 

--- a/src/AntiCorruptionLayer/AntiCorruptionMessageDispatcherTest.php
+++ b/src/AntiCorruptionLayer/AntiCorruptionMessageDispatcherTest.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace EventSauce\EventSourcing\AntiCorruptionLayer;
 
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\AllowAllMessages;
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\AllowMessagesWithPayloadOfType;
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\MessageFilter;
+use EventSauce\EventSourcing\AntiCorruptionLayer\Translators\MessageTranslator;
+use EventSauce\EventSourcing\AntiCorruptionLayer\Translators\PassthroughMessageTranslator;
 use EventSauce\EventSourcing\CollectingMessageDispatcher;
 use EventSauce\EventSourcing\Message;
 use PHPStan\Testing\TestCase;
-
 use function array_map;
 
 class AntiCorruptionMessageDispatcherTest extends TestCase
@@ -98,7 +102,7 @@ class AntiCorruptionMessageDispatcherTest extends TestCase
 
     /**
      * @test
-     * @dataProvider dpFilterAllButPublicAndPricate
+     * @dataProvider dpFilterAllButPublicAndPrivate
      */
     public function no_transformation_filter_all_but_public_and_private_payloads_after_transformation(
         array $incoming,
@@ -115,7 +119,7 @@ class AntiCorruptionMessageDispatcherTest extends TestCase
         $this->assertEquals($expected, $dispatchedEvents);
     }
 
-    public function dpFilterAllButPublicAndPricate(): iterable
+    public function dpFilterAllButPublicAndPrivate(): iterable
     {
         yield [[new StubPublicEvent('yes')], [new StubPublicEvent('yes')]];
         yield [[new StubPublicEvent('yes'), new StubExcludedEvent('no')], [new StubPublicEvent('yes')]];

--- a/src/AntiCorruptionLayer/MessageFilters/AllowAllMessages.php
+++ b/src/AntiCorruptionLayer/MessageFilters/AllowAllMessages.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EventSauce\EventSourcing\AntiCorruptionLayer;
+namespace EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters;
 
 use EventSauce\EventSourcing\Message;
 

--- a/src/AntiCorruptionLayer/MessageFilters/AllowAllMessagesTest.php
+++ b/src/AntiCorruptionLayer/MessageFilters/AllowAllMessagesTest.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
-namespace EventSauce\EventSourcing\AntiCorruptionLayer;
+namespace EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters;
 
+use EventSauce\EventSourcing\AntiCorruptionLayer\StubExcludedEvent;
+use EventSauce\EventSourcing\AntiCorruptionLayer\StubPrivateEvent;
+use EventSauce\EventSourcing\AntiCorruptionLayer\StubPublicEvent;
 use EventSauce\EventSourcing\Message;
 use PHPUnit\Framework\TestCase;
 

--- a/src/AntiCorruptionLayer/MessageFilters/AllowMessagesWithPayloadOfType.php
+++ b/src/AntiCorruptionLayer/MessageFilters/AllowMessagesWithPayloadOfType.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EventSauce\EventSourcing\AntiCorruptionLayer;
+namespace EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters;
 
 use EventSauce\EventSourcing\Message;
 

--- a/src/AntiCorruptionLayer/MessageFilters/AllowMessagesWithPayloadOfTypeTest.php
+++ b/src/AntiCorruptionLayer/MessageFilters/AllowMessagesWithPayloadOfTypeTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters;
+
+use EventSauce\EventSourcing\AntiCorruptionLayer\StubExcludedEvent;
+use EventSauce\EventSourcing\AntiCorruptionLayer\StubPrivateEvent;
+use EventSauce\EventSourcing\AntiCorruptionLayer\StubPublicEvent;
+use EventSauce\EventSourcing\Message;
+use PHPUnit\Framework\TestCase;
+
+class AllowMessagesWithPayloadOfTypeTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider dpMessagesWithPayloadOfType
+     */
+    public function matching_all_filters(object $event, bool $expectedOutcome): void
+    {
+        $filter = new AllowMessagesWithPayloadOfType(StubPublicEvent::class, StubPrivateEvent::class);
+
+        $result = $filter->allows(new Message($event));
+
+        $this->assertEquals($expectedOutcome, $result);
+    }
+
+    public function dpMessagesWithPayloadOfType(): iterable
+    {
+        yield [new StubPublicEvent('yes'), true];
+        yield [new StubPrivateEvent('yes'), true];
+        yield [new StubExcludedEvent('yes'), false];
+    }
+}

--- a/src/AntiCorruptionLayer/MessageFilters/MatchAllMessageFilterTest.php
+++ b/src/AntiCorruptionLayer/MessageFilters/MatchAllMessageFilterTest.php
@@ -2,12 +2,13 @@
 
 declare(strict_types=1);
 
-namespace EventSauce\EventSourcing\AntiCorruptionLayer;
+namespace EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters;
 
+use EventSauce\EventSourcing\AntiCorruptionLayer\StubPublicEvent;
 use EventSauce\EventSourcing\Message;
 use PHPUnit\Framework\TestCase;
 
-class MatchAnyMessageFilterTest extends TestCase
+class MatchAllMessageFilterTest extends TestCase
 {
     /**
      * @test
@@ -15,7 +16,7 @@ class MatchAnyMessageFilterTest extends TestCase
      */
     public function matching_all_filters(array $internalFilters, bool $expectedOutcome): void
     {
-        $filter = new MatchAnyMessageFilter(...$internalFilters);
+        $filter = new MatchAllMessageFilters(...$internalFilters);
 
         $result = $filter->allows(new Message(new StubPublicEvent('yes')));
 
@@ -25,8 +26,8 @@ class MatchAnyMessageFilterTest extends TestCase
     public function dpFilterCombinations(): iterable
     {
         yield [[new AllowAllMessages(), new AllowAllMessages()], true];
-        yield [[new NeverAllowMessages(), new AllowAllMessages()], true];
-        yield [[new AllowAllMessages(), new NeverAllowMessages()], true];
+        yield [[new NeverAllowMessages(), new AllowAllMessages()], false];
+        yield [[new AllowAllMessages(), new NeverAllowMessages()], false];
         yield [[new NeverAllowMessages(), new NeverAllowMessages()], false];
     }
 }

--- a/src/AntiCorruptionLayer/MessageFilters/MatchAllMessageFilters.php
+++ b/src/AntiCorruptionLayer/MessageFilters/MatchAllMessageFilters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EventSauce\EventSourcing\AntiCorruptionLayer;
+namespace EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters;
 
 use EventSauce\EventSourcing\Message;
 

--- a/src/AntiCorruptionLayer/MessageFilters/MatchAnyMessageFilter.php
+++ b/src/AntiCorruptionLayer/MessageFilters/MatchAnyMessageFilter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EventSauce\EventSourcing\AntiCorruptionLayer;
+namespace EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters;
 
 use EventSauce\EventSourcing\Message;
 

--- a/src/AntiCorruptionLayer/MessageFilters/MatchAnyMessageFilterTest.php
+++ b/src/AntiCorruptionLayer/MessageFilters/MatchAnyMessageFilterTest.php
@@ -2,12 +2,13 @@
 
 declare(strict_types=1);
 
-namespace EventSauce\EventSourcing\AntiCorruptionLayer;
+namespace EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters;
 
+use EventSauce\EventSourcing\AntiCorruptionLayer\StubPublicEvent;
 use EventSauce\EventSourcing\Message;
 use PHPUnit\Framework\TestCase;
 
-class MatchAllMessageFilterTest extends TestCase
+class MatchAnyMessageFilterTest extends TestCase
 {
     /**
      * @test
@@ -15,7 +16,7 @@ class MatchAllMessageFilterTest extends TestCase
      */
     public function matching_all_filters(array $internalFilters, bool $expectedOutcome): void
     {
-        $filter = new MatchAllMessageFilters(...$internalFilters);
+        $filter = new MatchAnyMessageFilter(...$internalFilters);
 
         $result = $filter->allows(new Message(new StubPublicEvent('yes')));
 
@@ -25,8 +26,8 @@ class MatchAllMessageFilterTest extends TestCase
     public function dpFilterCombinations(): iterable
     {
         yield [[new AllowAllMessages(), new AllowAllMessages()], true];
-        yield [[new NeverAllowMessages(), new AllowAllMessages()], false];
-        yield [[new AllowAllMessages(), new NeverAllowMessages()], false];
+        yield [[new NeverAllowMessages(), new AllowAllMessages()], true];
+        yield [[new AllowAllMessages(), new NeverAllowMessages()], true];
         yield [[new NeverAllowMessages(), new NeverAllowMessages()], false];
     }
 }

--- a/src/AntiCorruptionLayer/MessageFilters/MessageFilter.php
+++ b/src/AntiCorruptionLayer/MessageFilters/MessageFilter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EventSauce\EventSourcing\AntiCorruptionLayer;
+namespace EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters;
 
 use EventSauce\EventSourcing\Message;
 

--- a/src/AntiCorruptionLayer/MessageFilters/NeverAllowMessages.php
+++ b/src/AntiCorruptionLayer/MessageFilters/NeverAllowMessages.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EventSauce\EventSourcing\AntiCorruptionLayer;
+namespace EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters;
 
 use EventSauce\EventSourcing\Message;
 

--- a/src/AntiCorruptionLayer/MessageFilters/NeverAllowMessagesTest.php
+++ b/src/AntiCorruptionLayer/MessageFilters/NeverAllowMessagesTest.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
-namespace EventSauce\EventSourcing\AntiCorruptionLayer;
+namespace EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters;
 
+use EventSauce\EventSourcing\AntiCorruptionLayer\StubExcludedEvent;
+use EventSauce\EventSourcing\AntiCorruptionLayer\StubPrivateEvent;
+use EventSauce\EventSourcing\AntiCorruptionLayer\StubPublicEvent;
 use EventSauce\EventSourcing\Message;
 use PHPUnit\Framework\TestCase;
 

--- a/src/AntiCorruptionLayer/StubFilterExcludedMessages.php
+++ b/src/AntiCorruptionLayer/StubFilterExcludedMessages.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EventSauce\EventSourcing\AntiCorruptionLayer;
 
+use EventSauce\EventSourcing\AntiCorruptionLayer\MessageFilters\MessageFilter;
 use EventSauce\EventSourcing\Message;
 
 /**

--- a/src/AntiCorruptionLayer/StubTranslatePrivateToPublic.php
+++ b/src/AntiCorruptionLayer/StubTranslatePrivateToPublic.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EventSauce\EventSourcing\AntiCorruptionLayer;
 
+use EventSauce\EventSourcing\AntiCorruptionLayer\Translators\MessageTranslator;
 use EventSauce\EventSourcing\Message;
 
 /**

--- a/src/AntiCorruptionLayer/Translators/MessageTranslator.php
+++ b/src/AntiCorruptionLayer/Translators/MessageTranslator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EventSauce\EventSourcing\AntiCorruptionLayer;
+namespace EventSauce\EventSourcing\AntiCorruptionLayer\Translators;
 
 use EventSauce\EventSourcing\Message;
 

--- a/src/AntiCorruptionLayer/Translators/MessageTranslatorChain.php
+++ b/src/AntiCorruptionLayer/Translators/MessageTranslatorChain.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EventSauce\EventSourcing\AntiCorruptionLayer;
+namespace EventSauce\EventSourcing\AntiCorruptionLayer\Translators;
 
 use EventSauce\EventSourcing\Message;
 

--- a/src/AntiCorruptionLayer/Translators/MessageTranslatorChainTest.php
+++ b/src/AntiCorruptionLayer/Translators/MessageTranslatorChainTest.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EventSauce\EventSourcing\AntiCorruptionLayer;
+namespace EventSauce\EventSourcing\AntiCorruptionLayer\Translators;
 
+use EventSauce\EventSourcing\AntiCorruptionLayer\StubPublicEvent;
 use EventSauce\EventSourcing\Message;
 use PHPUnit\Framework\TestCase;
 

--- a/src/AntiCorruptionLayer/Translators/MessageTranslatorPerPayloadType.php
+++ b/src/AntiCorruptionLayer/Translators/MessageTranslatorPerPayloadType.php
@@ -2,10 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EventSauce\EventSourcing\AntiCorruptionLayer;
+namespace EventSauce\EventSourcing\AntiCorruptionLayer\Translators;
 
 use EventSauce\EventSourcing\Message;
-
 use function get_class;
 
 class MessageTranslatorPerPayloadType implements MessageTranslator

--- a/src/AntiCorruptionLayer/Translators/MessageTranslatorPerPayloadTypeTest.php
+++ b/src/AntiCorruptionLayer/Translators/MessageTranslatorPerPayloadTypeTest.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
-namespace EventSauce\EventSourcing\AntiCorruptionLayer;
+namespace EventSauce\EventSourcing\AntiCorruptionLayer\Translators;
 
+use EventSauce\EventSourcing\AntiCorruptionLayer\StubExcludedEvent;
+use EventSauce\EventSourcing\AntiCorruptionLayer\StubPrivateEvent;
+use EventSauce\EventSourcing\AntiCorruptionLayer\StubPublicEvent;
 use EventSauce\EventSourcing\Message;
 use PHPUnit\Framework\TestCase;
 

--- a/src/AntiCorruptionLayer/Translators/PassthroughMessageTranslator.php
+++ b/src/AntiCorruptionLayer/Translators/PassthroughMessageTranslator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EventSauce\EventSourcing\AntiCorruptionLayer;
+namespace EventSauce\EventSourcing\AntiCorruptionLayer\Translators;
 
 use EventSauce\EventSourcing\Message;
 


### PR DESCRIPTION
This moves Message filters and translators to their own namespaces. 

Also adds a test and fixes some small typo's