### PR TITLE
Message consumer testcase set aggregate id

### DIFF
--- a/src/TestUtilities/MessageConsumerTestCase.php
+++ b/src/TestUtilities/MessageConsumerTestCase.php
@@ -143,6 +143,16 @@ abstract class MessageConsumerTestCase extends TestCase
     }
 
     /**
+     * @after
+     *
+     * @throws Exception
+     */
+    protected function resetAggregateRootId(): void
+    {
+        $this->aggregateRootId = null;
+    }
+
+    /**
      * @return $this
      */
     public function then(callable $assertion)

--- a/src/TestUtilities/MessageConsumerTestCase.php
+++ b/src/TestUtilities/MessageConsumerTestCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EventSauce\EventSourcing\TestUtilities;
 
+use EventSauce\EventSourcing\AggregateRootId;
+use EventSauce\EventSourcing\Header;
 use EventSauce\EventSourcing\Message;
 use EventSauce\EventSourcing\MessageConsumer;
 use Exception;
@@ -20,6 +22,7 @@ abstract class MessageConsumerTestCase extends TestCase
      * @var callable
      */
     private $assertionCallback;
+    private ?AggregateRootId $aggregateRootId = null;
 
     abstract public function messageConsumer(): MessageConsumer;
 
@@ -74,12 +77,21 @@ abstract class MessageConsumerTestCase extends TestCase
         return $this;
     }
 
+    public function givenNextMessagesHaveAggregateRootIdOf(?AggregateRootId $aggregateRootId): self
+    {
+        $this->aggregateRootId = $aggregateRootId;
+        return $this;
+    }
+
     /**
      * @param object[] $eventsOrMessages
      */
     protected function processMessages(array $eventsOrMessages): void
     {
         $messages = $this->ensureEventsAreMessages($eventsOrMessages);
+        if (isset($this->aggregateRootId)) {
+            $messages = $this->ensureEventsHaveUuid($messages, $this->aggregateRootId);
+        }
 
         foreach ($messages as $message) {
             $this->messageConsumer->handle($message);
@@ -94,6 +106,18 @@ abstract class MessageConsumerTestCase extends TestCase
         return array_map(function (object $event) {
             return $event instanceof Message ? $event : new Message($event);
         }, $events);
+    }
+
+    /**
+     * @return Message[]
+     */
+    private function ensureEventsHaveUuid(array $messages, AggregateRootId $aggregateRootId): array
+    {
+        return array_map(function (Message $message) use ($aggregateRootId) {
+            return $message->withHeaders([
+                Header::AGGREGATE_ROOT_ID => $aggregateRootId,
+            ]);
+        }, $messages);
     }
 
     /**

--- a/src/TestUtilities/TestingMessageConsumers/TestedMessageConsumer.php
+++ b/src/TestUtilities/TestingMessageConsumers/TestedMessageConsumer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EventSauce\EventSourcing\TestUtilities\TestingMessageConsumers;
 
+use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\Message;
 use EventSauce\EventSourcing\MessageConsumer;
 use LogicException;
@@ -12,6 +13,7 @@ class TestedMessageConsumer implements MessageConsumer
 {
     private int $failAfterNumberOfMessages;
     private int $numberOfMessagesProcessed = 0;
+    private ?AggregateRootId $lastProcessedUuid;
 
     public function __construct(int $failAfterNumberOfMessages)
     {
@@ -23,10 +25,16 @@ class TestedMessageConsumer implements MessageConsumer
         if (++$this->numberOfMessagesProcessed === $this->failAfterNumberOfMessages) {
             throw new LogicException('Too many messages');
         }
+        $this->lastProcessedUuid = $message->aggregateRootId();
     }
 
     public function numberOfMessagesProcessed(): int
     {
         return $this->numberOfMessagesProcessed;
+    }
+
+    public function lastProcessedUuid(): ?AggregateRootId
+    {
+        return $this->lastProcessedUuid ?? null;
     }
 }

--- a/src/TestUtilities/TestingMessageConsumers/TestedMessageConsumerTest.php
+++ b/src/TestUtilities/TestingMessageConsumers/TestedMessageConsumerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EventSauce\EventSourcing\TestUtilities\TestingMessageConsumers;
 
 use DomainException;
+use EventSauce\EventSourcing\DummyAggregateRootId;
 use EventSauce\EventSourcing\Message;
 use EventSauce\EventSourcing\MessageConsumer;
 use EventSauce\EventSourcing\TestUtilities\MessageConsumerTestCase;
@@ -65,6 +66,23 @@ class TestedMessageConsumerTest extends MessageConsumerTestCase
         );
         $this->expectToFail(new DomainException('Wrong exception'));
         $this->assertScenario();
+    }
+
+    /**
+     * @test
+     */
+    public function it_sets_aggregate_uuid_in_message(): void
+    {
+        $aggregateRootId = DummyAggregateRootId::generate();
+        $this
+            ->givenNextMessagesHaveAggregateRootIdOf($aggregateRootId)
+            ->given(
+                new ConsumerEvent(),
+            )->when(
+                new ConsumerEvent(),
+            )->then(function (TestedMessageConsumer $consumer) use ($aggregateRootId): void {
+                $this->assertEquals($aggregateRootId, $consumer->lastProcessedUuid());
+            });
     }
 
     /**


### PR DESCRIPTION
I find myself adding the aggregate id to messages in my consumer tests, resulting in them being less readable. (you have to construct the messages in your testcase, instead of just passing the event). 

This little helper sets the uuid of the next messages to make test classes more elegant.

```
$this
            ->givenNextMessagesHaveAggregateRootIdOf($aggregateRootId)
            ->given(
                new ConsumerEvent(),
            )->when(
                new ConsumerEvent(),
            )->then(function (TestedMessageConsumer $consumer) use ($aggregateRootId): void {
                $this->assertEquals($aggregateRootId, $consumer->lastProcessedUuid());
            });
```

 