### PR TITLE
Feature: Event consumer strategies

### DIFF
--- a/src/EventConsumer.php
+++ b/src/EventConsumer.php
@@ -8,12 +8,17 @@ abstract class EventConsumer implements MessageConsumer
 {
     public function handle(Message $message): void
     {
-        $event = $message->payload();
-        $parts = explode('\\', get_class($event));
-        $method = 'handle' . end($parts);
+        $methods = $this->getInflector()->getMethodNames($this, $message);
 
-        if (method_exists($this, $method)) {
-            $this->{$method}($event, $message);
+        foreach ($methods as $method) {
+            if (method_exists($this, $method)) {
+                $this->{$method}($message->payload(), $message);
+            }
         }
+    }
+
+    protected function getInflector(): HandleInflector
+    {
+        return new InflectHandlersFromClassName();
     }
 }

--- a/src/HandleInflector.php
+++ b/src/HandleInflector.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\EventSourcing;
+
+interface HandleInflector
+{
+    /**
+     * @return string[]
+     */
+    public function getMethodNames(object $consumer, Message $message): array;
+}

--- a/src/InflectHandlersFromClassName.php
+++ b/src/InflectHandlersFromClassName.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\EventSourcing;
+
+class InflectHandlersFromClassName implements HandleInflector
+{
+    public function getMethodNames(object $consumer, Message $message): array
+    {
+        $event = $message->payload();
+        $parts = explode('\\', get_class($event));
+
+        return ['handle' . end($parts)];
+    }
+}

--- a/src/InflectHandlersFromClassNameTest.php
+++ b/src/InflectHandlersFromClassNameTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\EventSourcing;
+
+use EventSauce\EventSourcing\LibraryConsumptionTests\EventConsumption\DummyEventForConsuming;
+use PHPUnit\Framework\TestCase;
+
+class InflectHandlersFromClassNameTest extends TestCase
+{
+    /** @test */
+    public function it_inflects_the_name_from_the_event_class_name(): void
+    {
+        $inflector = new InflectHandlersFromClassName();
+
+        $names = $inflector->getMethodNames(new \stdClass(), new Message(new DummyEventForConsuming('')));
+
+        $this->assertContains('handleDummyEventForConsuming', $names);
+    }
+}

--- a/src/InflectHandlersFromType.php
+++ b/src/InflectHandlersFromType.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\EventSourcing;
+
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionType;
+use ReflectionUnionType;
+
+class InflectHandlersFromType implements HandleInflector
+{
+    public function getMethodNames(object $consumer, Message $message): array
+    {
+        $event = $message->payload();
+        $methods = $this->getEventHandlingMethods($consumer);
+
+        return $methods[$event::class] ?? [];
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public function getEventHandlingMethods(object $handler): array
+    {
+        $handlerClass = new ReflectionClass($handler);
+
+        $methods = $handlerClass->getMethods(ReflectionMethod::IS_PUBLIC);
+
+        $handlers = [];
+
+        foreach ($methods as $method) {
+            if ( ! $type = $this->firstParameterType($method)) {
+                continue;
+            }
+
+            $acceptedTypes = $this->acceptedTypes($type);
+
+            foreach ($acceptedTypes as $type) {
+                $handlers[$type->getName()][] = $method->getName();
+            }
+        }
+
+        return $handlers;
+    }
+
+    protected function firstParameterType(ReflectionMethod $method): ?ReflectionType
+    {
+        $parameter = $method->getParameters()[0] ?? null;
+
+        return $parameter?->getType();
+    }
+
+    /**
+     * @return ReflectionNamedType[]
+     */
+    protected function acceptedTypes(ReflectionType $type): array
+    {
+        if ($type instanceof ReflectionNamedType) {
+            return [$type];
+        } elseif ($type instanceof ReflectionUnionType) {
+            return $type->getTypes();
+        }
+
+        return [];
+    }
+}

--- a/src/InflectHandlersFromTypeTest.php
+++ b/src/InflectHandlersFromTypeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\EventSourcing;
+
+use EventSauce\EventSourcing\LibraryConsumptionTests\EventConsumption\DummyEventForConsuming;
+use PHPUnit\Framework\TestCase;
+
+class InflectHandlersFromTypeTest extends TestCase
+{
+    /** @test */
+    public function it_inflects_the_method_name_from_the_event_type_and_available_methods(): void
+    {
+        $inflector = new InflectHandlersFromType();
+
+        $names = $inflector->getMethodNames(new TypedEventConsumer(), new Message(new DummyEventForConsuming('')));
+
+        $this->assertContains('onDummyEvent', $names);
+        $this->assertContains('shouldIncludeUnion', $names);
+        $this->assertNotContains('shouldNotIncludeOtherEvent', $names);
+        $this->assertNotContains('shouldNotIncludeProtectedMethod', $names);
+        $this->assertNotContains('shouldNotIncludePrivateMethod', $names);
+    }
+}
+
+class TypedEventConsumer extends EventConsumer
+{
+    public function onDummyEvent(DummyEventForConsuming $event): void
+    {
+    }
+
+    public function shouldIncludeUnion(DummyEventForConsuming|DummyEvent $event): void
+    {
+    }
+
+    public function shouldNotIncludeOtherEvent(DummyEvent $event): void
+    {
+    }
+
+    private function shouldNotIncludeProtectedMethod(DummyEventForConsuming $event): void
+    {
+    }
+
+    private function shouldNotIncludePrivateMethod(DummyEventForConsuming $event): void
+    {
+    }
+}


### PR DESCRIPTION
Building upon the features introduced with #62, this PR adds a backwards compatible strategy to determine which methods to call for an event.

The new strategy uses reflection to match the types of the methods to the event class. It enabled the uses of union types to have a single method react to multiple events.