### PR TITLE
Correct example to match with current interface in documentation

### DIFF
--- a/docs/docs/event-sourcing/2-create-events-and-commands.md
+++ b/docs/docs/event-sourcing/2-create-events-and-commands.md
@@ -70,7 +70,7 @@ class SomeEvent implements SerializablePayload
         return ['property' => $this->property];
     }
 
-    public static function fromPayload(array $payload): SerializablePayload
+    public static function fromPayload(array $payload): static
     {
         return new SomeEvent($payload['property']);
     }


### PR DESCRIPTION
When working on setting up EventSauce on a local POC I ran into issues as the example copied from the site didn't work.
To avoid other people from running into the same here is a small correction replacing the `SerializablePayload` with `static` as it is defined in the [interface](https://github.com/EventSaucePHP/EventSauce/blob/main/src/Serialization/SerializablePayload.php#L11)