### PR TITLE
Dropped V1 indicator from documentation

### DIFF
--- a/docs/docs/event-sourcing/3-configure-persistence.md
+++ b/docs/docs/event-sourcing/3-configure-persistence.md
@@ -16,7 +16,7 @@ repository has specific methods to query messages that belong to a single aggreg
 A message repository should only be used for reconstitution. Performing arbitrary queries
 on the underlying database is not advised, use a projection for this instead.
 
-There are 3 message repository implementations shipped for v1:
+There are 3 message repository implementations shipped:
 
 - [Illuminate Message Repository](/docs/message-storage/illuminate/)
 - [Doctrine 3 Message Repository](/docs/message-storage/doctrine-3/)


### PR DESCRIPTION
Dropped V1 indicator as all three implementations exists for V1, V2 and V3 which as this point only is overhead if all three versions would be mentioned (and possible future upkeep if/when a V4 would be released. 