### PR TITLE
Add missing template to AggregateRootBehaviourWithRequiredHistory

### DIFF
--- a/src/AggregateRootBehaviourWithRequiredHistory.php
+++ b/src/AggregateRootBehaviourWithRequiredHistory.php
@@ -6,8 +6,14 @@ namespace EventSauce\EventSourcing;
 
 use Generator;
 
+/**
+ * @template AggregateRootIdType of AggregateRootId
+ *
+ * @see AggregateRoot
+ */
 trait AggregateRootBehaviourWithRequiredHistory
 {
+    /** @phstan-use AggregateRootBehaviour<AggregateRootIdType> */
     use AggregateRootBehaviour {
         AggregateRootBehaviour::reconstituteFromEvents as private defaultAggregateRootReconstitute;
     }


### PR DESCRIPTION
In PHPStan 1.9.* we are able to use @phpstan-use to include generic traits. This is correctly done on AggregateRootBehaviour but missing on AggregateRootBehaviourWithRequiredHistory.