### PR TITLE
Make template for AggregateRootId a covariant template

### DIFF
--- a/src/AggregateRoot.php
+++ b/src/AggregateRoot.php
@@ -7,7 +7,7 @@ namespace EventSauce\EventSourcing;
 use Generator;
 
 /**
- * @template AggregateRootIdType of AggregateRootId
+ * @template-covariant AggregateRootIdType of AggregateRootId
  *
  * @see AggregateRootBehaviour
  */


### PR DESCRIPTION
See vimeo/psalm#9161 - the `@template-covariant` annotation should be applied to the AggregateRoot interface, since it should allow any covariant AggregateRootId implementation.