### PR TITLE
Fix typos & wording in documentation

### DIFF
--- a/docs/docs/advanced/anti-corruption-layer.md
+++ b/docs/docs/advanced/anti-corruption-layer.md
@@ -310,6 +310,3 @@ class AntiCorruptionLayerTest extends AntiCorruptionLayerTestCase
     }
 }
 ```
-
-
-

--- a/docs/docs/advanced/database-structure.md
+++ b/docs/docs/advanced/database-structure.md
@@ -55,7 +55,7 @@ The prefix (or suffix) is named after the aggregate root.
 ## Table per aggregate identifier.
 
 In this approach the messages will be assigned to a table per aggregate identifier. Tables will be
-create dynamically. Table names generally follow a naming scheme consisting of the aggregate type
+created dynamically. Table names generally follow a naming scheme consisting of the aggregate type
 and identifier, like "orders_[order process id]".
 
 ### Pro's

--- a/docs/docs/advanced/message-decoration.md
+++ b/docs/docs/advanced/message-decoration.md
@@ -16,7 +16,7 @@ the _aggregate root id_ by turning it into a string and adding type information.
 ## Time Of Recording
 
 Storing the time of recording lets us replay events in the same order they
-originally happened and it's extremely useful for business analyics too!
+originally happened and it's extremely useful for business analytics too!
 
 Almost every event sourcing project eventually comes to a point where the
 timing of events (and/or commands) becomes significant. Having this information

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -81,7 +81,7 @@ The aggregate root repository has the following dependencies:
 1. An aggregate root class name (so it knows what to reconstitute and return)
 2. A [message repository](#message-repository) from which it retrieves previously recorded events
 3. A [message dispatcher](#message-dispatcher) which dispatches the messages _(optional)_
-3. A [message decorator](#message-decorator) which decorates the messages _(optional)_
+4. A [message decorator](#message-decorator) which decorates the messages _(optional)_
 
 ### Message repository
 

--- a/docs/docs/code-generation/about.md
+++ b/docs/docs/code-generation/about.md
@@ -3,9 +3,9 @@ permalink: /docs/code-generation/
 title: Code Generation
 ---
 
-EventSauce provides an simple and opinionated way to generate code. Code generation
-is not always to everybody's liking. However, when correct in the right circumstances,
-code generation is a great accelerator during your time spent writing code.
+EventSauce provides a simple and opinionated way to generate code. Code generation
+is not always to everybody's liking. However, given the right circumstances,
+code generation is a great accelerator to your time spent writing code.
 
 ## Simple data transfer objects.
 

--- a/docs/docs/event-sourcing.md
+++ b/docs/docs/event-sourcing.md
@@ -26,7 +26,7 @@ objects, stored in an append-only manner.
 ## When event sourcing shines
 
 Event sourcing shines where traditional modeling techniques fall short.
-It is well suites for modeling complex business processes.
+It is well suited for modeling complex business processes.
 
 ## How is it different?
 
@@ -59,7 +59,7 @@ It'll just be clear.
 
 ## The cost and trade-offs
 
-Coming from data-centric modeling, event sourcing is a pretty big paradigm shifts.
+Coming from data-centric modeling, event sourcing is a pretty big paradigm shift.
 It is also not a cost-free solution. Like many things in our work-field, by introducing
 event sourcing into your application you're trading one set of problems for another.
 You're opting in to certain things, and out of others.
@@ -69,7 +69,7 @@ The upside to this is that you can now build a number of different ways to view 
 data from the events.
 
 In general, event sourcing is a lot more verbose. You'll often have to introduce
-some additional pieces of infrastructural. It's possible to minimize this initial
+some additional pieces of infrastructure. It's possible to minimize this initial
 investment, but like any trade-off, this comes as a cost.
 
 ## The pay-off

--- a/docs/docs/event-sourcing/2-create-events-and-commands.md
+++ b/docs/docs/event-sourcing/2-create-events-and-commands.md
@@ -25,8 +25,8 @@ By default the `MessageSerializer` uses the `PayloadSerializer` to serialize
 events. This serializer requires events to implement the `SerializablePayload`
 interface. This interface requires you to implement **2** public functions:
 
-> 2. `toPayload(): array`
-> 3. `fromPayload(array $payload): SerializablePayload`
+> 1. `toPayload(): array`
+> 2. `fromPayload(array $payload): SerializablePayload`
 
 ## To and From payload
 

--- a/docs/docs/event-sourcing/4-bootstrap.md
+++ b/docs/docs/event-sourcing/4-bootstrap.md
@@ -9,8 +9,8 @@ Now that you've got your `MessageRepository` and `MessageDispatcher` in place
 you're ready to bootstrap your `AggregateRootRepository`.
 
 The `AggregateRootRepository` is the main interface of EventSauce. It's where
-you get your aggregate root from and where you persist (persist recorded events)
-it. When you're retrieving an aggregate root from the repository it's responsible
+you get your aggregate root from and where you persist recorded events.
+When you're retrieving an aggregate root from the repository it's responsible
 for fetching the associated events from the `MessageRepository` and using that
 to create an aggregate root. This process is commonly referred to as
 **reconstituting an aggregate root**.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -29,7 +29,7 @@ since the technique is based on communication.
 
 EventSauce is a no-nonsense event sourcing library for PHP with a focus on developer
 experience and productivity. This library was developed with the idea that you should
-remain in control of . No application-wide rewrites and no big investments upfront.
+remain in control. No application-wide rewrites and no big investments upfront.
 
 ## You are in control
 
@@ -40,7 +40,7 @@ can use it in your application, but you can also copy it and take full control.
 ## Extensible by design
 
 The core is built around a set of (tiny) interfaces, which gives you the freedom to choose
-the tools that meet your requirements. Implement them however you deem fit. EventSauce
+the tools that meet your requirements. Implement them however you see fit. EventSauce
 was built favoring composition (not inheritance), this allows it to be composed in whatever
 way is suitable for your project.
 

--- a/docs/docs/lifecycle.md
+++ b/docs/docs/lifecycle.md
@@ -11,7 +11,7 @@ The lifecycle of EventSauce can be broken down into **3** steps:
 
 ## Interacting with the model
 
-In order to interact with your model  you'll need to
+In order to interact with your model you'll need to
 retrieve the `AggregateRoot` from the `AggregateRootRepository`.
 
 ### Retrieving the `AggregateRoot`
@@ -105,7 +105,7 @@ $repository->persist($aggregateRoot);
 When you persist the events from an aggregate root the following things happen:
 
 1. Events are pulled from the aggregate root.
-2. The events are wrapped in a `Message` objects.
+2. The events are wrapped in `Message` objects.
 3. The message objects are decorated (optional).
 4. The messages are persisted in the `MessageRepository`.
 5. The messages are dispatched by the `MessageDispatcher`.

--- a/docs/docs/message-outbox/setup-and-usage.md
+++ b/docs/docs/message-outbox/setup-and-usage.md
@@ -7,9 +7,9 @@ title: Message Outbox Setup and Usage
 ---
 
 The outbox module consists of three parts, a _repository_, a _dispatcher_ and a
-_relay_. The repository is responsible storing and retrieving  messages. The
-dispatcher is responsible for putting messages  in the repository and hooks into
-the core by implementing the `MessageDispatcher` interface.  The relay is
+_relay_. The repository is responsible storing and retrieving messages. The
+dispatcher is responsible for putting messages in the repository and hooks into
+the core by implementing the `MessageDispatcher` interface. The relay is
 responsible for fetching messages from the repository and committing them (mark
 as consumed or delete).
 
@@ -17,7 +17,7 @@ as consumed or delete).
 
 Your messages should be stored in the same database as our regular message
 repository does. This may sound like we're needlessly storing twice but each
-table has its own responsibility, and we interact with the in distinct ways.
+table has its own responsibility, and we interact with them in distinct ways.
 
 Messages stored in the outbox table are expected to be deleted or marked as
 consumed while our normal messages are intended to stay around for as long as

--- a/docs/docs/message-outbox/table-schema.md
+++ b/docs/docs/message-outbox/table-schema.md
@@ -3,7 +3,7 @@ permalink: /docs/message-outbox/table-schema/
 title: Message Outbox Table Schema
 ---
 
-Outbox setups come in all shapes and sized. Unless you know what you're
+Outbox setups come in all shapes and sizes. Unless you know what you're
 doing, you're advised to default to one outbox per aggregate root type.
 
 Below is a highly optimized database schema, perfect for an outbox table:

--- a/docs/docs/message-storage/index.md
+++ b/docs/docs/message-storage/index.md
@@ -3,11 +3,11 @@ permalink: /docs/message-storage/
 title: About Message Storage
 ---
 
-Message Storage in event sourcing consists of a couple components. Messages contain
+Message Storage in event sourcing consists of a couple of components. Messages contain
 the events that an aggregate root needs to rebuild itself, a Message Repository
 is used to store and retrieve messages for this purpose. Messages can also be stored
-temporarily in a database to ensure transaction dispatching to asynchronous consumer,
-a Transactional Outbox (or Outbox for short) is used to facilitate that.
+temporarily in a database to ensure transaction dispatching to an asynchronous consumer.
+A Transactional Outbox (or Outbox for short) is used to facilitate that.
 
 ## Message Repositories
 

--- a/docs/docs/serialization/plain-serialization.md
+++ b/docs/docs/serialization/plain-serialization.md
@@ -4,7 +4,7 @@ title: Serialization using ObjectMapper
 ---
 
 The plain serialization strategy uses an interface to ensure events comply with the needs to serialize and
-deserialize events using handwritten property mapping. This strategy is the default, therefor now setup is required.
+deserialize events using handwritten property mapping. This strategy is the default, therefore no setup is required.
 
 ## Creating events
 

--- a/docs/docs/snapshotting/index.md
+++ b/docs/docs/snapshotting/index.md
@@ -31,6 +31,6 @@ stream of events.
 
 ## Versioning Snapshots
 
-Snapshots are stored in the database. When your aggregate root evolves, so must your snapshots. A good practise is to
+Snapshots are stored in the database. When your aggregate root evolves, so must your snapshots. A good practice is to
 version your snapshots. Storing a version along with your snapshot allows you to filter out any outdated ones when
 trying to fetch your aggregate root.

--- a/docs/docs/snapshotting/setup.md
+++ b/docs/docs/snapshotting/setup.md
@@ -99,7 +99,7 @@ $aggregateRepository = new ConstructingAggregateRootRepositoryWithSnapshotting(
 
 As you can see above, the repository requires the regular repository to be injected
 into it. This allows you to transparently replace the existing usage without
-breaking anything. In addition you now have added snapshot capabilities to the repository!
+breaking anything. In addition, you now have added snapshot capabilities to the repository!
 
 ## 3. Use it in your application.
 

--- a/docs/docs/testing/asserting-the-payload-of-an-event.md
+++ b/docs/docs/testing/asserting-the-payload-of-an-event.md
@@ -44,7 +44,7 @@ class DummyIncrementTest extends DummyAggregateRootTestCase
             );
     } 
     
-        /**
+    /**
      * @test
      */
     public function it_dispatches_a_event_when_incrementing_using_return_of_closure()

--- a/docs/docs/testing/handling-exception.md
+++ b/docs/docs/testing/handling-exception.md
@@ -58,4 +58,4 @@ protected function handle($command)
 
 The `finally` clause will be triggered even though an exception is thrown. In
 this case the events recorded prior to the exception are still recorded but
-your exception still bubbles up so you can handle it transparently.
+your exception still bubbles up, so you can handle it transparently.


### PR DESCRIPTION
This updates the documentation to fix some typos and minor issues with sentence structure.