### PR TITLE
ci: Update deprecated set-output command to use GITHUB environment files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}


### PR DESCRIPTION
Update as per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Warnings can been seen at https://github.com/EventSaucePHP/EventSauce/actions/runs/5250334300