### PR TITLE
Fix typo in AggregateRootBehaviourWithRequiredHistory

### DIFF
--- a/src/AggregateRootBehaviourWithRequiredHistory.php
+++ b/src/AggregateRootBehaviourWithRequiredHistory.php
@@ -13,7 +13,7 @@ use Generator;
  */
 trait AggregateRootBehaviourWithRequiredHistory
 {
-    /** @phstan-use AggregateRootBehaviour<AggregateRootIdType> */
+    /** @phpstan-use AggregateRootBehaviour<AggregateRootIdType> */
     use AggregateRootBehaviour {
         AggregateRootBehaviour::reconstituteFromEvents as private defaultAggregateRootReconstitute;
     }


### PR DESCRIPTION
Fixes a typo: `phstan` should be `phpstan`