### PR TITLE
Fix incorrect aggregate root ID type on `AggregateRootWithAggregates`

### DIFF
--- a/src/AggregateRootWithAggregates.php
+++ b/src/AggregateRootWithAggregates.php
@@ -7,10 +7,14 @@ namespace EventSauce\EventSourcing;
 use SplObjectStorage;
 
 /**
+ * @template AggregateRootIdType of AggregateRootId
  * @template T of EventSourcedAggregate
  */
 trait AggregateRootWithAggregates
 {
+    /**
+     * @use AggregateRootBehaviour<AggregateRootIdType>
+     */
     use AggregateRootBehaviour, AggregateAppliesKnownEvents {
         AggregateAppliesKnownEvents::apply as applyOnAggregateRoot;
     }


### PR DESCRIPTION
### What does this fix?

The `AggregateRootWithAggregates` breaks type inference for the aggregate root's ID. When using this trait PHPStan will always infer the type as `EventSauce\EventSourcing\AggregateRootId`

For example:

```php
final class FooId implements AggregateRootId
{
    public function toString(): string
    {
        return 'foo';
    }

    public static function fromString(string $aggregateRootId): static
    {
        return new self();
    }
}

/**
 * @implements AggregateRoot<FooId>
 */
final class Foo implements AggregateRoot
{
    /**
     * @use AggregateRootWithAggregates<FooId, EventSourcedAggregate>
     */
    use AggregateRootWithAggregates;

    public function weCannotInferKeyType(): void
    {
        dumpType($this->aggregateRootId()); // Dumped type: EventSauce\EventSourcing\AggregateRootId
    }
}
```

With this PR you'd have to add `FooId` to the `@use` statement, after which `$this->aggregateRootId()` would be typed as `FooId`.

### Something to take note of

While this fixes the mistyping completely, it could be considered a breaking change as adding a new template to a trait will surely cause some PHPStan workflows to fail.