### PR TITLE
Fix Uuid encoding page title

### DIFF
--- a/docs/docs/message-storage/uuid-encoding.md
+++ b/docs/docs/message-storage/uuid-encoding.md
@@ -1,6 +1,6 @@
 ---
 permalink: /docs/message-storage/uuid-encoding/
-title: Message Repository Table Schema
+title: Uuid Enconding
 ---
 
 [![Packagist Version](https://img.shields.io/packagist/v/eventsauce/uuid-encoding.svg?style=flat-square)](https://packagist.org/packages/eventsauce/uuid-encoding)


### PR DESCRIPTION
Current [title](https://eventsauce.io/docs/message-storage/uuid-encoding/) is Message Repository Table Schema, should be Uuid Encoding