### PR TITLE
Allow PHPUnit 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr/clock": "^1.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.8.6",
+        "phpstan/phpstan": "^1.11.11",
         "phpunit/phpunit": "^9.5.23|^10.0|^11.0",
         "nikic/php-parser": "^v4.10.4",
         "symfony/yaml": "^5.0 | ^6.0 | ^7.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,5 +10,7 @@ parameters:
         - *Test.php
     ignoreErrors:
         - '#^Method EventSauce\\EventSourcing\\EventConsumption\\TypedEventConsumerStub\:\:.+\(\) is unused.#'
+        - '#^Attribute class PHPUnit\\Framework\\Attributes\\Before does not exist.#'
+        - '#^Attribute class PHPUnit\\Framework\\Attributes\\After does not exist.#'
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,8 +9,12 @@ parameters:
         - %rootDir%/../../../tests/*
         - *Test.php
     ignoreErrors:
+        - identifier: missingType.iterableValue
+        - identifier: missingType.generics
         - '#^Method EventSauce\\EventSourcing\\EventConsumption\\TypedEventConsumerStub\:\:.+\(\) is unused.#'
-        - '#^Attribute class PHPUnit\\Framework\\Attributes\\Before does not exist.#'
-        - '#^Attribute class PHPUnit\\Framework\\Attributes\\After does not exist.#'
-    checkMissingIterableValueType: false
-    checkGenericClassInNonGenericObjectType: false
+        -
+            message: '#^Attribute class PHPUnit\\Framework\\Attributes\\Before does not exist.#'
+            reportUnmatched: false
+        -
+            message: '#^Attribute class PHPUnit\\Framework\\Attributes\\After does not exist.#'
+            reportUnmatched: false

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 vendor/bin/phpunit --coverage-text --coverage-html coverage && \
-vendor/bin/phpstan analyze -l 5 src -c phpstan.neon
+vendor/bin/phpstan analyze src -c phpstan.neon

--- a/src/TestUtilities/AggregateRootTestCase.php
+++ b/src/TestUtilities/AggregateRootTestCase.php
@@ -27,6 +27,8 @@ use EventSauce\EventSourcing\Serialization\PayloadSerializer;
 use EventSauce\EventSourcing\SynchronousMessageDispatcher;
 use Exception;
 use LogicException;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Throwable;
@@ -86,6 +88,7 @@ abstract class AggregateRootTestCase extends TestCase
     /**
      * @before
      */
+    #[Before]
     protected function setUpEventSauce(): void
     {
         $className = $this->aggregateRootClassName();
@@ -119,6 +122,7 @@ abstract class AggregateRootTestCase extends TestCase
     /**
      * @after
      */
+    #[After]
     protected function assertScenario(): void
     {
         // @codeCoverageIgnoreStart

--- a/src/TestUtilities/MessageConsumerTestCase.php
+++ b/src/TestUtilities/MessageConsumerTestCase.php
@@ -9,6 +9,8 @@ use EventSauce\EventSourcing\Header;
 use EventSauce\EventSourcing\Message;
 use EventSauce\EventSourcing\MessageConsumer;
 use Exception;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\TestCase;
 
 abstract class MessageConsumerTestCase extends TestCase
@@ -29,6 +31,7 @@ abstract class MessageConsumerTestCase extends TestCase
     /**
      * @before
      */
+    #[Before]
     public function setupMessageConsumer(): void
     {
         $this->messageConsumer = $this->messageConsumer();
@@ -38,6 +41,7 @@ abstract class MessageConsumerTestCase extends TestCase
     /**
      * @before
      */
+    #[Before]
     public function unsetMessageConsumer(): void
     {
         unset($this->messageConsumer);
@@ -126,6 +130,7 @@ abstract class MessageConsumerTestCase extends TestCase
      *
      * @throws Exception
      */
+    #[After]
     protected function assertScenario(): void
     {
         // @codeCoverageIgnoreStart
@@ -148,6 +153,7 @@ abstract class MessageConsumerTestCase extends TestCase
      *
      * @throws Exception
      */
+    #[After]
     protected function resetAggregateRootId(): void
     {
         $this->aggregateRootId = null;

--- a/src/TestUtilities/composer.json
+++ b/src/TestUtilities/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^8.0",
         "eventsauce/eventsauce": "^2.0 | ^3.0",
-        "phpunit/phpunit": "^8.5|^9.4|^10.0|^11.0"
+        "phpunit/phpunit": "^8.5|^9.4|^10.0|^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Having attributes should not break for those who use old phpunit where these don't exist.
Annotations won't work anymore in PhpUnit 12.

Have used a similar approach before.