### PR TITLE
Improve collected payload type hints

### DIFF
--- a/src/CollectingMessageConsumer.php
+++ b/src/CollectingMessageConsumer.php
@@ -21,6 +21,9 @@ class CollectingMessageConsumer implements MessageConsumer
         return $this->collectedMessages;
     }
 
+    /**
+     * @return object[]
+     */
     public function collectedPayloads(): array
     {
         return array_map(fn (Message $message) => $message->payload(), $this->collectedMessages);

--- a/src/CollectingMessageDispatcher.php
+++ b/src/CollectingMessageDispatcher.php
@@ -27,8 +27,11 @@ class CollectingMessageDispatcher implements MessageDispatcher
         return $this->collectedMessages;
     }
 
+    /**
+     * @return object[]
+     */
     public function collectedPayloads(): array
     {
-        return array_map(fn (Message $message) => $message->event(), $this->collectedMessages);
+        return array_map(fn (Message $message) => $message->payload(), $this->collectedMessages);
     }
 }


### PR DESCRIPTION
Also replaced a call to `Message::event()` (which is deprecated), with `Message::payload()`