### PR TITLE
Add non-empty-string type annotations to AggregateRootId interface

### DIFF
--- a/src/AggregateRootId.php
+++ b/src/AggregateRootId.php
@@ -6,7 +6,11 @@ namespace EventSauce\EventSourcing;
 
 interface AggregateRootId
 {
+    /** @return non-empty-string */
     public function toString(): string;
 
+    /**
+     * @param non-empty-string $aggregateRootId
+     */
     public static function fromString(string $aggregateRootId): static;
 }

--- a/src/DummyAggregateRootId.php
+++ b/src/DummyAggregateRootId.php
@@ -9,8 +9,12 @@ namespace EventSauce\EventSourcing;
  */
 final class DummyAggregateRootId implements AggregateRootId
 {
+    /** @var non-empty-string */
     private string $identifier;
 
+    /**
+     * @param non-empty-string $identifier
+     */
     public function __construct(string $identifier)
     {
         $this->identifier = $identifier;

--- a/src/Snapshotting/Tests/LightSwitchId.php
+++ b/src/Snapshotting/Tests/LightSwitchId.php
@@ -8,6 +8,9 @@ use EventSauce\EventSourcing\AggregateRootId;
 
 final class LightSwitchId implements AggregateRootId
 {
+    /**
+     * @param non-empty-string $id
+     */
     public function __construct(private string $id)
     {
     }


### PR DESCRIPTION
**What changed:**
- Added `@return non-empty-string` annotation to the `toString()` method
- Added `@param non-empty-string $aggregateRootId` annotation to the `fromString()` method

**Why this change:**
This enhancement improves type safety by explicitly documenting that aggregate root IDs must be non-empty strings. This helps with:

- **Static analysis**: PHPStan/Psalm can now catch potential issues where empty strings might be passed or returned
- **Developer experience**: IDEs will provide better type hints and warnings
- **Documentation**: Makes the interface contract clearer about expected string values
- **Runtime safety**: Prevents subtle bugs from empty string IDs being used in the domain

**Breaking changes:**
None - this is purely additive type annotation that doesn't affect runtime behavior.

**Testing:**
Existing tests continue to pass as this only adds static type information.