### PR TITLE
Set event ID when persisting messages

### DIFF
--- a/src/EventSourcedAggregateRootRepository.php
+++ b/src/EventSourcedAggregateRootRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EventSauce\EventSourcing;
 
 use Generator;
+use Ramsey\Uuid\Uuid;
 use Throwable;
 
 use function assert;
@@ -98,7 +99,10 @@ class EventSourcedAggregateRootRepository implements AggregateRootRepository
         $messages = array_map(function (object $event) use ($metadata, &$aggregateRootVersion) {
             return $this->decorator->decorate(new Message(
                 $event,
-                $metadata + [Header::AGGREGATE_ROOT_VERSION => ++$aggregateRootVersion]
+                $metadata + [
+                    Header::AGGREGATE_ROOT_VERSION => ++$aggregateRootVersion,
+                    Header::EVENT_ID => Uuid::uuid4()->toString(),
+                ],
             ));
         }, $events);
 


### PR DESCRIPTION
Alternative to https://github.com/EventSaucePHP/MessageStorage/pull/38

Currently when a message is persisted, the event ID is not set until the very last moment (when the message is inserted into the database). This causes outbox repositories and message dispatchers to receive message instances that do not have this header set.

This PR changes the `EventSourcedAggregateRootRepository` to always set the event ID when constructing messages, so that repositories, outboxes and dispatchers always receive the same message headers. Unlike https://github.com/EventSaucePHP/MessageStorage/pull/38, this covers both message repositories and dispatchers, the downside to this approach is that if someone uses a decorator to generate their own event IDs the aggregate root repository will now do useless work