### PR TITLE
Fix PHP 8.5 deprecations

### DIFF
--- a/src/AggregateRootWithAggregates.php
+++ b/src/AggregateRootWithAggregates.php
@@ -49,14 +49,14 @@ trait AggregateRootWithAggregates
     private function registerAggregate(?EventSourcedAggregate $aggregate): void
     {
         if ($aggregate instanceof EventSourcedAggregate) {
-            $this->aggregatesInsideRoot()->attach($aggregate);
+            $this->aggregatesInsideRoot()->offsetSet($aggregate);
         }
     }
 
     private function unregisterAggregate(?EventSourcedAggregate $aggregate): void
     {
         if ($aggregate instanceof EventSourcedAggregate) {
-            $this->aggregatesInsideRoot()->detach($aggregate);
+            $this->aggregatesInsideRoot()->offsetUnset($aggregate);
         }
     }
 


### PR DESCRIPTION
Fixes #245 

`SplObjectStorage::attach()` and `SplObjectStorage::detach()` have been deprecated as of PHP 8.5

Documentation:
- https://www.php.net/manual/en/splobjectstorage.attach.php
- https://www.php.net/manual/en/splobjectstorage.detach.php