### PR TITLE
refactor(test-utilities): generic-type AggregateRootTestCase

### DIFF
--- a/src/LibraryConsumptionTests/AggregateWithDelegatedBehavior/AggregateRootWithDelegatedBehaviorTest.php
+++ b/src/LibraryConsumptionTests/AggregateWithDelegatedBehavior/AggregateRootWithDelegatedBehaviorTest.php
@@ -9,7 +9,7 @@ use EventSauce\EventSourcing\DummyAggregateRootId;
 use EventSauce\EventSourcing\TestUtilities\AggregateRootTestCase;
 
 /**
- * @method DummyAggregateRootId aggregateRootId()
+ * @extends AggregateRootTestCase<DummyAggregateRootId, AggregateRootWithDelegatedBehavior>
  */
 class AggregateRootWithDelegatedBehaviorTest extends AggregateRootTestCase
 {

--- a/src/LibraryConsumptionTests/ShoppingCartExample/ShoppingCartTestCase.php
+++ b/src/LibraryConsumptionTests/ShoppingCartExample/ShoppingCartTestCase.php
@@ -7,6 +7,9 @@ namespace EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample;
 use Closure;
 use EventSauce\EventSourcing\TestUtilities\AggregateRootTestCase;
 
+/**
+ * @extends AggregateRootTestCase<ShoppingCartId, ShoppingCart>
+ */
 class ShoppingCartTestCase extends AggregateRootTestCase
 {
     protected function newAggregateRootId(): ShoppingCartId
@@ -21,7 +24,6 @@ class ShoppingCartTestCase extends AggregateRootTestCase
 
     public function handle(Closure $closure): void
     {
-        /** @var ShoppingCart $aggregate */
         $aggregate = $this->repository->retrieve($this->aggregateRootId);
         $closure($aggregate);
         $this->repository->persist($aggregate);

--- a/src/Snapshotting/Tests/AggregateSnapshottingTest.php
+++ b/src/Snapshotting/Tests/AggregateSnapshottingTest.php
@@ -15,6 +15,9 @@ use EventSauce\EventSourcing\Snapshotting\InMemorySnapshotRepository;
 use EventSauce\EventSourcing\Snapshotting\Snapshot;
 use EventSauce\EventSourcing\TestUtilities\AggregateRootTestCase;
 
+/**
+ * @extends AggregateRootTestCase<LightSwitchId, LightSwitch>
+ */
 class AggregateSnapshottingTest extends AggregateRootTestCase
 {
     protected InMemorySnapshotRepository $snapshotRepository;

--- a/src/Snapshotting/Tests/LightSwitchTest.php
+++ b/src/Snapshotting/Tests/LightSwitchTest.php
@@ -8,7 +8,7 @@ use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\TestUtilities\AggregateRootTestCase;
 
 /**
- * @method LightSwitchId aggregateRootId()
+ * @extends AggregateRootTestCase<LightSwitchId, LightSwitch>
  */
 class LightSwitchTest extends AggregateRootTestCase
 {
@@ -68,7 +68,6 @@ class LightSwitchTest extends AggregateRootTestCase
             return;
         }
 
-        /** @var LightSwitch $lightSwitch */
         $lightSwitch = $this->retrieveAggregateRoot($command->id());
 
         if ($command instanceof TurnLightOn) {

--- a/src/TestUtilities/AggregateRootTestCase.php
+++ b/src/TestUtilities/AggregateRootTestCase.php
@@ -41,6 +41,9 @@ use function method_exists;
 use function sprintf;
 
 /**
+ * @template AggregateRootIdType of AggregateRootId
+ * @template AggregateRootType of AggregateRoot<AggregateRootIdType>
+ *
  * @method handle(...$arguments)
  */
 abstract class AggregateRootTestCase extends TestCase
@@ -51,7 +54,7 @@ abstract class AggregateRootTestCase extends TestCase
     protected $messageRepository;
 
     /**
-     * @phpstan-var AggregateRootRepository<AggregateRoot>
+     * @phpstan-var AggregateRootRepository<AggregateRootType>
      */
     protected AggregateRootRepository $repository;
 
@@ -81,7 +84,7 @@ abstract class AggregateRootTestCase extends TestCase
     private $assertedScenario = false;
 
     /**
-     * @var AggregateRootId
+     * @var AggregateRootIdType
      */
     protected $aggregateRootId;
 
@@ -109,11 +112,17 @@ abstract class AggregateRootTestCase extends TestCase
         $this->caughtException = null;
     }
 
+    /**
+     * @return AggregateRootType
+     */
     protected function retrieveAggregateRoot(AggregateRootId $id): object
     {
         return $this->repository->retrieve($id);
     }
 
+    /**
+     * @param AggregateRootType $aggregateRoot
+     */
     protected function persistAggregateRoot(AggregateRoot $aggregateRoot): void
     {
         $this->repository->persist($aggregateRoot);
@@ -142,15 +151,21 @@ abstract class AggregateRootTestCase extends TestCase
         }
     }
 
+    /**
+     * @return AggregateRootIdType
+     */
     protected function aggregateRootId(): AggregateRootId
     {
         return $this->aggregateRootId;
     }
 
+    /**
+     * @return AggregateRootIdType
+     */
     abstract protected function newAggregateRootId(): AggregateRootId;
 
     /**
-     * @phpstan-return class-string<AggregateRoot>
+     * @phpstan-return class-string<AggregateRootType>
      */
     abstract protected function aggregateRootClassName(): string;
 

--- a/src/TestUtilities/TestingAggregates/ExampleAggregateRootTest.php
+++ b/src/TestUtilities/TestingAggregates/ExampleAggregateRootTest.php
@@ -16,7 +16,7 @@ use LogicException;
 use PHPUnit\Framework\ExpectationFailedException;
 
 /**
- * @method DummyAggregateRootId aggregateRootId()
+ * @extends AggregateRootTestCase<DummyAggregateRootId, DummyAggregate>
  */
 class ExampleAggregateRootTest extends AggregateRootTestCase
 {

--- a/src/TestUtilities/TestingAggregates/TestCaseMustHaveHandleMethodsTest.php
+++ b/src/TestUtilities/TestingAggregates/TestCaseMustHaveHandleMethodsTest.php
@@ -10,7 +10,7 @@ use EventSauce\EventSourcing\TestUtilities\AggregateRootTestCase;
 use LogicException;
 
 /**
- * @method DummyAggregateRootId aggregateRootId()
+ * @extends AggregateRootTestCase<DummyAggregateRootId, DummyAggregate>
  */
 class TestCaseMustHaveHandleMethodsTest extends AggregateRootTestCase
 {

--- a/tests/ShoppingCartTestCase.php
+++ b/tests/ShoppingCartTestCase.php
@@ -8,6 +8,9 @@ use EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\Shoppin
 use EventSauce\EventSourcing\LibraryConsumptionTests\ShoppingCartExample\ShoppingCartId;
 use EventSauce\EventSourcing\TestUtilities\AggregateRootTestCase;
 
+/**
+ * @extends AggregateRootTestCase<ShoppingCartId, ShoppingCart>
+ */
 abstract class ShoppingCartTestCase extends AggregateRootTestCase
 {
     protected function newAggregateRootId(): ShoppingCartId
@@ -22,7 +25,6 @@ abstract class ShoppingCartTestCase extends AggregateRootTestCase
 
     public function handle(Closure $closure): void
     {
-        /** @var ShoppingCart $aggregate */
         $aggregate = $this->repository->retrieve($this->aggregateRootId);
         $closure($aggregate);
         $this->repository->persist($aggregate);


### PR DESCRIPTION
PHPStan couldn't narrow aggregateRootId(), retrieveAggregateRoot(), and persistAggregateRoot() past the AggregateRootId/AggregateRoot interfaces, so subclasses relied on @method docblock overrides and manual @var casts to get concrete types back in their test bodies.

Bind AggregateRootIdType and AggregateRootType via @template on the base class so concrete test cases only need to declare @extends AggregateRootTestCase<Id, AggregateRoot> to propagate the narrowed types everywhere, and drop the now-redundant workarounds from the classes that extend it.